### PR TITLE
implementing new MET corrections

### DIFF
--- a/interface/GlobalVariables.h
+++ b/interface/GlobalVariables.h
@@ -53,6 +53,9 @@ struct Globals {
 
 	//MET
 	static METAlgorithm::value metAlgorithm;
+	static bool applySysShiftMetCorrection;
+	static bool applyType0MetCorrection;
+	static bool applyType1MetCorrection;
 
 	//miscellaneous
 	static std::string custom_file_suffix;

--- a/interface/Python/ConfigFile.h
+++ b/interface/Python/ConfigFile.h
@@ -47,6 +47,9 @@ public:
 	int BtagSystematic() const;
 	std::string custom_file_suffix() const;
 	unsigned int pdfWeightNumber() const;
+	bool applyMetSysShiftCorr() const;
+	bool applyMetType0Corr() const;
+	bool applyMetType1Corr() const;
 
 private:
 	boost::program_options::variables_map programOptions;
@@ -69,6 +72,9 @@ private:
 	std::string custom_file_suffix_;
 	unsigned int pdfWeightNumber_;
 //	PileUpReweightingMethod::value pileUpReweightingMethod_;
+	bool applyMetSysShiftCorr_;
+	bool applyMetType0Corr_;
+	bool applyMetType1Corr_;
 
 	boost::program_options::variables_map getParameters(int argc, char **argv);
 	boost::shared_ptr<TH1D> getPileUpHistogram(std::string pileUpEstimationFile);

--- a/interface/Readers/METCorrReader.h
+++ b/interface/Readers/METCorrReader.h
@@ -1,0 +1,36 @@
+/*
+ * METCorrReader.h
+ *
+ *  Created on: Nov 15, 2012
+ *      Author: phzss
+ */
+
+#ifndef METCORRREADER_H_
+#define METCORRREADER_H_
+
+#include "VariableReader.h"
+#include "../RecoObjects/MET.h"
+
+namespace BAT {
+
+class METCorrReader {
+public:
+	METCorrReader();
+	METCorrReader(TChainPointer input, METCorrections::value correction);
+	const double getXcorrection();
+	const double getYcorrection();
+	virtual ~METCorrReader();
+	void initialise();
+	void initialiseBlindly();
+	void readMETCorrections();
+private:
+	VariableReader<double> corrxReader;
+	VariableReader<double> corryReader;
+
+	double corrx, corry;
+	METCorrections::value usedCorrections;
+};
+
+}
+
+#endif /* METCORRREADER_H_ */

--- a/interface/Readers/METReader.h
+++ b/interface/Readers/METReader.h
@@ -16,7 +16,7 @@ class METReader {
 public:
 	METReader();
 	METReader(TChainPointer input, METAlgorithm::value algo = METAlgorithm::patMETsPFlow);
-	const METPointer getMET();
+	const METPointer getMET(double corrx, double corry);
 	virtual ~METReader();
 	void initialise();
 	void initialiseBlindly();
@@ -29,7 +29,7 @@ private:
 	VariableReader<double> significanceReader;
 	METPointer met;
 	METAlgorithm::value usedAlgorithm;
-	void readMET();
+	void readMET(double corrx, double corry);
 };
 
 }

--- a/interface/Readers/NTupleEventReader.h
+++ b/interface/Readers/NTupleEventReader.h
@@ -19,11 +19,11 @@
 #include "VariableReader.h"
 #include "VertexReader.h"
 #include "METReader.h"
+#include "METCorrReader.h"
 #include "GenMETReader.h"
 #include "TrackReader.h"
 #include "GenParticleReader.h"
 #include <string>
-#include "TTreePerfStats.h"
 
 namespace BAT {
 struct NoFileFoundException: public std::exception {
@@ -76,6 +76,7 @@ private:
 	boost::scoped_ptr<MuonReader> muonReader;
 //	boost::scoped_ptr<GenMETReader> genMetReader;
 	std::vector<boost::shared_ptr<METReader> > metReaders;
+	std::vector<boost::shared_ptr<METCorrReader> > metCorrReaders;
 
 	boost::scoped_ptr<VariableReader<unsigned int> > runNumberReader;
 	boost::scoped_ptr<VariableReader<unsigned int> > eventNumberReader;

--- a/interface/RecoObjects/MET.h
+++ b/interface/RecoObjects/MET.h
@@ -14,6 +14,21 @@
 
 namespace BAT {
 
+namespace METCorrections {
+enum value {
+	pfMetSysShiftCorrections,
+	pfMetType0Corrections,
+	pfMetType1Corrections,
+	NUMBER_OF_METCORRECTIONS
+};
+
+const boost::array<std::string, METCorrections::NUMBER_OF_METCORRECTIONS> prefixes = { {
+		//MET correction names as stored in the nTuples
+				"pfMetSysShiftCorrections", //
+				"pfMetType0Corrections", //
+				"pfMetType1Corrections" } };
+}
+
 namespace METAlgorithm {
 enum value {
 	patMETsPFlow, GenMET, patType1CorrectedPFMet, patType1p2CorrectedPFMet,

--- a/python/default_cfg.py
+++ b/python/default_cfg.py
@@ -11,6 +11,10 @@ maxEvents = 100
 #integrated luminosity the MC simulation will be scaled to
 lumi = 5050#pb-1
 
+#MET corrections setup
+applyMetSysShiftCorr = False
+applyMetType0Corr = False
+applyMetType1Corr = False 
 
 if centerOfMassEnergy == 8:
     #File for pile-up re-weighting

--- a/src/Analysers/METAnalyser.cpp
+++ b/src/Analysers/METAnalyser.cpp
@@ -32,7 +32,7 @@ void METAnalyser::analyse(const EventPtr event) {
 			histMan_->H2D_BJetBinned("RecoMET_vs_GenMET")->Fill(event->GenMET()->et(), met->et(), weight_);
 		}
 		//do not fill other histograms for met systematics
-		if (index > METAlgorithm::patType1p2CorrectedPFMet)
+		if ( (index > METAlgorithm::patType1p2CorrectedPFMet) && (index != METAlgorithm::recoMetPFlow))
 			continue;
 		histMan_->H1D_BJetBinned("MET_phi")->Fill(met->phi(), weight_);
 		histMan_->H1D_BJetBinned("METsignificance")->Fill(met->significance(), weight_);
@@ -98,7 +98,7 @@ void METAnalyser::createHistograms() {
 		}
 
 		//do not create other histograms for met systematics
-		if (index > METAlgorithm::patType1p2CorrectedPFMet)
+		if ( (index > METAlgorithm::patType1p2CorrectedPFMet) && (index != METAlgorithm::recoMetPFlow))
 			continue;
 		histMan_->addH1D_BJetBinned("MET_phi", "#phi(Missing transverse energy);#phi(#slash{E}_{T});Events/0.1", 80, -4,
 				4);

--- a/src/GlobalsVariables.cpp
+++ b/src/GlobalsVariables.cpp
@@ -50,6 +50,9 @@ boost::array< boost::shared_ptr<TF1>, 12 > Globals::lightL7Corrections = {{
 
 //MET
 METAlgorithm::value Globals::metAlgorithm = METAlgorithm::patType1CorrectedPFMet;
+bool Globals::applySysShiftMetCorrection = false;
+bool Globals::applyType0MetCorrection = false;
+bool Globals::applyType1MetCorrection = false;
 
 std::string Globals::custom_file_suffix = "";
 unsigned int Globals::pdfWeightNumber = 0;

--- a/src/Readers/METCorrReader.cpp
+++ b/src/Readers/METCorrReader.cpp
@@ -1,0 +1,62 @@
+/*
+ * METCorrReader.cpp
+ *
+ *  Created on: Nov 15, 2012
+ *      Author: phzss
+ */
+
+#include "../../interface/Readers/METCorrReader.h"
+#include "../../interface/GlobalVariables.h"
+
+namespace BAT {
+
+METCorrReader::METCorrReader() :
+		corrxReader(), //
+		corryReader(), //
+		corrx(), //
+		corry(), //
+		usedCorrections(METCorrections::pfMetSysShiftCorrections) {
+
+}
+
+METCorrReader::METCorrReader(TChainPointer input, METCorrections::value correction) :
+				corrxReader(input, METCorrections::prefixes.at(correction) + ".x"), //
+				corryReader(input, METCorrections::prefixes.at(correction) + ".y"), //
+				corrx(), //
+				corry(), //
+				usedCorrections(METCorrections::pfMetSysShiftCorrections) {
+
+}
+
+METCorrReader::~METCorrReader() {
+}
+
+void METCorrReader::initialise() {
+	corrxReader.initialise();
+	corryReader.initialise();
+}
+
+void METCorrReader::initialiseBlindly() {
+	corrxReader.initialiseBlindly();
+	corryReader.initialiseBlindly();
+}
+
+const double METCorrReader::getXcorrection() {
+	return corrx;
+}
+
+const double METCorrReader::getYcorrection() {
+	return corry;
+}
+
+void METCorrReader::readMETCorrections() {
+	if (Globals::NTupleVersion > 8) {
+		corrx = corrxReader.getVariable();
+		corry = corryReader.getVariable();
+	} else {
+		corrx = 0;
+		corry = 0;
+	}
+
+}
+}

--- a/src/Readers/METReader.cpp
+++ b/src/Readers/METReader.cpp
@@ -55,14 +55,14 @@ void METReader::initialiseBlindly() {
 
 }
 
-const METPointer METReader::getMET() {
-	readMET();
+const METPointer METReader::getMET(double corrx, double corry) {
+	readMET(corrx, corry);
 	return met;
 }
 
-void METReader::readMET() {
+void METReader::readMET(double corrx, double corry) {
 	if (usedAlgorithm != METAlgorithm::GenMET || Globals::NTupleVersion >= 8) {
-		met = METPointer(new MET(exReader.getVariable(), eyReader.getVariable()));
+		met = METPointer(new MET(exReader.getVariable()+corrx, eyReader.getVariable()+corry));
 		met->setSignificance(significanceReader.getVariable());
 	} else
 		met = METPointer(new MET(multiExReader.getVariableAt(0), multiEyReader.getVariableAt(0)));


### PR DESCRIPTION
This bit of code reads the new MET corrections that are stored in the nTuples (>= v9) and applies them to each MET according to corresponding Global Variables, which can be set in the python configuration file. By default, corrections are not applied.
