### PR TITLE
Getting rid of the old CiC electron ID

### DIFF
--- a/interface/Event.h
+++ b/interface/Event.h
@@ -150,7 +150,6 @@ public:
 	int HLTPrescale(HLTriggers::value trigger) const;
 	static bool useCustomConversionTagger;
 	static bool usePFIsolation;
-	static bool useCiCElectronID;
 
 	const std::vector<int> GeneratedPileUpVertices() const;
 	const std::vector<double> PDFWeights() const;

--- a/interface/Readers/ElectronReader.h
+++ b/interface/Readers/ElectronReader.h
@@ -66,7 +66,6 @@ private:
 	VariableReader<MultiDoublePointer> vertex_dist_z;
 	VariableReader<MultiDoublePointer> dist;
 	VariableReader<MultiDoublePointer> dCotTheta;
-	boost::scoped_ptr<VariableReader<MultiIntPointer> > CiCElectronIDReader;
 	VariableReader<MultiDoublePointer> mvaTrigV0_, mvaNonTrigV0_;
 	VariableReader<MultiBoolPointer> passConversionVeto_;
 

--- a/interface/RecoObjects/Electron.h
+++ b/interface/RecoObjects/Electron.h
@@ -42,21 +42,6 @@ enum value {
 };
 }
 
-namespace CiCElectronID {
-enum value {
-    eidVeryLooseMC,
-    eidLooseMC,
-    eidMediumMC,
-    eidTightMC,
-    eidSuperTightMC,
-    eidHyperTight1MC,
-    eidHyperTight2MC,
-    eidHyperTight3MC,
-    eidHyperTight4MC,
-    NUMBER_OF_CiCIds
-};
-}
-
 namespace ElectronID {
 enum value {
 	SimpleCutBasedWP95 = -9,
@@ -64,15 +49,6 @@ enum value {
 	SimpleCutBasedWP70 = -7,
 	MVAIDTrigger = -6,
 	MVAIDNonTrigger = -5,
-	CiCVeryLooseMC = 0,
-	CiCLooseMC = 1,
-	CiCMediumMC = 2,
-	CiCTightMC = 3,
-	CiCSuperTightMC = 4,
-	CiCHyperTight1MC = 5,
-	CiCHyperTight2MC = 6,
-	CiCHyperTight3MC = 7,
-	CiCHyperTight4MC = 8
 };
 
 
@@ -108,7 +84,6 @@ public:
     double distToClosestTrack() const;
     bool VBTF_WP70_ElectronID() const;
     bool VBTF_WP95_ElectronID() const;
-    bool CiC_ElectronID(CiCElectronID::value id) const;
     bool QCD_AntiID_WP70() const;
     bool QCD_AntiID_WP70_Barrel() const;
     bool QCD_AntiID_WP70_Endcap() const;
@@ -138,7 +113,6 @@ public:
     void setSharedFractionInnerHits(double hits);
     void setDistToNextTrack(double dist);
     void setDCotThetaToNextTrack(double dCotTheta);
-    void setCompressedCiCElectronID(int electronID);
     void setMVATrigV0(double mva);
     void setMVANonTrigV0(double mva);
     void setPassConversionVeto(bool passes);
@@ -161,7 +135,6 @@ private:
     double innerLayerMissingHits_;
     //used for electron ID
     double sigma_IEtaIEta, dPhi_In, dEta_In, hadOverEm;
-    int CiCElectronIDCompressed_;
     TrackPointer gsfTrack;
     int closesTrackID;
     double sharedFractionInnerHits;

--- a/src/Readers/ElectronReader.cpp
+++ b/src/Readers/ElectronReader.cpp
@@ -55,7 +55,6 @@ ElectronReader::ElectronReader() : //
 		vertex_dist_z(), //
 		dist(), //
 		dCotTheta(), //
-		CiCElectronIDReader(), //
 		mvaTrigV0_(), //
 		mvaNonTrigV0_(), //
 		passConversionVeto_(), //
@@ -108,8 +107,6 @@ ElectronReader::ElectronReader(TChainPointer input, ElectronAlgorithm::value alg
 		vertex_dist_z(input, ElectronAlgorithm::prefixes.at(algo) + ".VtxDistZ"), //
 		dist(input, ElectronAlgorithm::prefixes.at(algo) + ".Dist"), //
 		dCotTheta(input, ElectronAlgorithm::prefixes.at(algo) + ".DCotTheta"), //
-		CiCElectronIDReader(
-				new VariableReader<MultiIntPointer>(input, ElectronAlgorithm::prefixes.at(algo) + ".PassID")), //
 		mvaTrigV0_(input, ElectronAlgorithm::prefixes.at(algo) + ".mvaTrigV0"), //
 		mvaNonTrigV0_(input, ElectronAlgorithm::prefixes.at(algo) + ".mvaNonTrigV0"), //
 		passConversionVeto_(input, ElectronAlgorithm::prefixes.at(algo) + ".passConversionVeto"), //
@@ -158,8 +155,6 @@ void ElectronReader::readElectrons() {
 		electron->setHadOverEm(hadOverEmReader.getVariableAt(index));
 		electron->setDistToNextTrack(dist.getVariableAt(index));
 		electron->setDCotThetaToNextTrack(dCotTheta.getVariableAt(index));
-
-		electron->setCompressedCiCElectronID(CiCElectronIDReader->getIntVariableAt(index));
 
 		if (algorithm == ElectronAlgorithm::ParticleFlow) {
 			electron->setPFGammaIsolation(PFGammaIsolationReader_DR03_.getVariableAt(index), 0.3);
@@ -237,7 +232,6 @@ void ElectronReader::initialise() {
 	vertex_dist_z.initialise();
 	dist.initialise();
 	dCotTheta.initialise();
-	CiCElectronIDReader->initialise();
 	if (algorithm == ElectronAlgorithm::ParticleFlow) {
 		PFGammaIsolationReader_DR03_.initialise();
 		PFChargedHadronIsolationReader_DR03_.initialise();

--- a/src/RecoObjects/Electron.cpp
+++ b/src/RecoObjects/Electron.cpp
@@ -28,7 +28,6 @@ Electron::Electron() :
 		dPhi_In(initialBigValue), //
 		dEta_In(initialBigValue), //
 		hadOverEm(initialBigValue), //
-		CiCElectronIDCompressed_(0), //
 		gsfTrack(), //
 		closesTrackID(-1), //
 		sharedFractionInnerHits(0), //
@@ -49,7 +48,6 @@ Electron::Electron(double energy, double px, double py, double pz) :
 		dPhi_In(initialBigValue), //
 		dEta_In(initialBigValue), //
 		hadOverEm(initialBigValue), //
-		CiCElectronIDCompressed_(0), //
 		gsfTrack(), //
 		closesTrackID(-1), //
 		sharedFractionInnerHits(0), //
@@ -167,10 +165,7 @@ bool Electron::passesElectronID(short leptonID) const {
 	case ElectronID::MVAIDNonTrigger:
 		return mvaNonTrigV0() > 0.0;
 	default:
-		if (electronID >= ElectronID::CiCVeryLooseMC)
-			return CiC_ElectronID((CiCElectronID::value) electronID);
-		else
-			return false;
+		return mvaTrigV0() > 0.0;
 	}
 }
 
@@ -406,15 +401,6 @@ double Electron::distToClosestTrack() const {
 
 double Electron::dCotThetaToClosestTrack() const {
 	return dCotThetaToNextTrack_;
-}
-
-void Electron::setCompressedCiCElectronID(int electronID) {
-	CiCElectronIDCompressed_ = electronID;
-}
-
-bool Electron::CiC_ElectronID(CiCElectronID::value electronID) const {
-	// compressedId bit-wise and with the mask
-	return CiCElectronIDCompressed_ & (1 << (int) electronID);
 }
 
 bool Electron::isPFLepton() const {

--- a/test/TestElectron.cpp
+++ b/test/TestElectron.cpp
@@ -567,116 +567,6 @@ void TestElectron::testGSFTrack() {
 	ASSERT_EQUAL(track, goodElectron->GSFTrack());
 }
 
-void TestElectron::testCiCElectronIDVeryLooseMC() {
-	int passId = 0;
-	CiCElectronID::value IDunderTest = (CiCElectronID::value) ElectronID::CiCVeryLooseMC;
-	passId = passId | 1 << (int) IDunderTest;
-
-	goodElectron->setCompressedCiCElectronID(passId);
-	ASSERT(goodElectron->CiC_ElectronID(IDunderTest));
-}
-
-void TestElectron::testCiCElectronIDLooseMC() {
-	int passId = 0;
-	CiCElectronID::value IDunderTest = CiCElectronID::eidLooseMC;
-	passId = passId | 1 << (int) IDunderTest;
-
-	goodElectron->setCompressedCiCElectronID(passId);
-	ASSERT(goodElectron->CiC_ElectronID(IDunderTest));
-}
-
-void TestElectron::testCiCElectronIDMediumMC() {
-	int passId = 0;
-	CiCElectronID::value IDunderTest = CiCElectronID::eidMediumMC;
-	passId = passId | 1 << (int) IDunderTest;
-
-	goodElectron->setCompressedCiCElectronID(passId);
-	ASSERT(goodElectron->CiC_ElectronID(IDunderTest));
-}
-
-void TestElectron::testCiCElectronIDTightMC() {
-	int passId = 0;
-	CiCElectronID::value IDunderTest = CiCElectronID::eidTightMC;
-	passId = passId | 1 << (int) IDunderTest;
-
-	goodElectron->setCompressedCiCElectronID(passId);
-	ASSERT(goodElectron->CiC_ElectronID(IDunderTest));
-}
-
-void TestElectron::testCiCElectronIDSuperTightMC() {
-	int passId = 0;
-	CiCElectronID::value IDunderTest = CiCElectronID::eidSuperTightMC;
-	passId = passId | 1 << (int) IDunderTest;
-
-	goodElectron->setCompressedCiCElectronID(passId);
-	ASSERT(goodElectron->CiC_ElectronID(IDunderTest));
-}
-
-void TestElectron::testCiCElectronIDHyperTight1MC() {
-	int passId = 0;
-	CiCElectronID::value IDunderTest = CiCElectronID::eidHyperTight1MC;
-	passId = passId | 1 << (int) IDunderTest;
-
-	goodElectron->setCompressedCiCElectronID(passId);
-	ASSERT(goodElectron->CiC_ElectronID(IDunderTest));
-}
-
-void TestElectron::testCiCElectronIDHyperTight2MC() {
-	int passId = 0;
-	CiCElectronID::value IDunderTest = CiCElectronID::eidHyperTight2MC;
-	passId = passId | 1 << (int) IDunderTest;
-
-	goodElectron->setCompressedCiCElectronID(passId);
-	ASSERT(goodElectron->CiC_ElectronID(IDunderTest));
-}
-
-void TestElectron::testCiCElectronIDHyperTight3MC() {
-	int passId = 0;
-	CiCElectronID::value IDunderTest = CiCElectronID::eidHyperTight3MC;
-	passId = passId | 1 << (int) IDunderTest;
-
-	goodElectron->setCompressedCiCElectronID(passId);
-	ASSERT(goodElectron->CiC_ElectronID(IDunderTest));
-}
-
-void TestElectron::testCiCElectronIDHyperTight4MC() {
-	int passId = 0;
-	CiCElectronID::value IDunderTest = CiCElectronID::eidHyperTight4MC;
-	passId = passId | 1 << (int) IDunderTest;
-	goodElectron->setCompressedCiCElectronID(passId);
-	ASSERT(goodElectron->CiC_ElectronID(IDunderTest));
-	ASSERT(!goodElectron->CiC_ElectronID(CiCElectronID::eidHyperTight3MC));
-}
-
-void TestElectron::testCiCElectronIDNoID() {
-	int passId = 0;
-	goodElectron->setCompressedCiCElectronID(passId);
-	//if passId = 0 all IDs should be false
-	for (unsigned int id = 0; id < CiCElectronID::NUMBER_OF_CiCIds; ++id)
-		ASSERT(!goodElectron->CiC_ElectronID((CiCElectronID::value) id));
-}
-
-void TestElectron::testCiCElectronIDMoreThanOneID() {
-	int passId = 0;
-	goodElectron->setCompressedCiCElectronID(passId);
-	CiCElectronID::value IDunderTest = CiCElectronID::eidHyperTight3MC;
-	CiCElectronID::value otherIDunderTest = CiCElectronID::eidHyperTight4MC;
-	passId = passId | 1 << (int) IDunderTest;
-	passId = passId | 1 << (int) otherIDunderTest;
-
-	goodElectron->setCompressedCiCElectronID(passId);
-
-	for (unsigned int id = 0; id < CiCElectronID::NUMBER_OF_CiCIds; ++id) {
-		CiCElectronID::value testId = (CiCElectronID::value) id;
-		if (testId == IDunderTest || testId == otherIDunderTest) {
-			ASSERT(goodElectron->CiC_ElectronID(testId));
-		} else {
-			ASSERT(!goodElectron->CiC_ElectronID(testId));
-		}
-	}
-
-}
-
 cute::suite make_suite_TestElectron() {
 	cute::suite s;
 	s.push_back(CUTE_SMEMFUN(TestElectron, testRelativeIsolation));
@@ -733,18 +623,6 @@ cute::suite make_suite_TestElectron() {
 	s.push_back(CUTE_SMEMFUN(TestElectron, testElectronInCollection));
 	s.push_back(CUTE_SMEMFUN(TestElectron, testElectronSetMass));
 	s.push_back(CUTE_SMEMFUN(TestElectron, testElectronInSTDCollection));
-
-	s.push_back(CUTE_SMEMFUN(TestElectron, testCiCElectronIDVeryLooseMC));
-	s.push_back(CUTE_SMEMFUN(TestElectron, testCiCElectronIDLooseMC));
-	s.push_back(CUTE_SMEMFUN(TestElectron, testCiCElectronIDMediumMC));
-	s.push_back(CUTE_SMEMFUN(TestElectron, testCiCElectronIDTightMC));
-	s.push_back(CUTE_SMEMFUN(TestElectron, testCiCElectronIDSuperTightMC));
-	s.push_back(CUTE_SMEMFUN(TestElectron, testCiCElectronIDHyperTight1MC));
-	s.push_back(CUTE_SMEMFUN(TestElectron, testCiCElectronIDHyperTight2MC));
-	s.push_back(CUTE_SMEMFUN(TestElectron, testCiCElectronIDHyperTight3MC));
-	s.push_back(CUTE_SMEMFUN(TestElectron, testCiCElectronIDHyperTight4MC));
-	s.push_back(CUTE_SMEMFUN(TestElectron, testCiCElectronIDNoID));
-	s.push_back(CUTE_SMEMFUN(TestElectron, testCiCElectronIDMoreThanOneID));
 
 	s.push_back(CUTE_SMEMFUN(TestElectron, testGSFTrack));
 	return s;

--- a/test/TestElectron.h
+++ b/test/TestElectron.h
@@ -79,17 +79,6 @@ public:
 	void testElectronInSTDCollection();
 	void testElectronSetMass();
 	void testGSFTrack();
-	void testCiCElectronIDVeryLooseMC();
-	void testCiCElectronIDLooseMC();
-	void testCiCElectronIDMediumMC();
-	void testCiCElectronIDTightMC();
-	void testCiCElectronIDSuperTightMC();
-	void testCiCElectronIDHyperTight1MC();
-	void testCiCElectronIDHyperTight2MC();
-	void testCiCElectronIDHyperTight3MC();
-	void testCiCElectronIDHyperTight4MC();
-	void testCiCElectronIDNoID();
-	void testCiCElectronIDMoreThanOneID();
 };
 
 extern cute::suite make_suite_TestElectron();

--- a/test/TestElectronReader.cpp
+++ b/test/TestElectronReader.cpp
@@ -67,51 +67,6 @@ void TestElectronReader::testShFracInnerHits() {
 	ASSERT_EQUAL(0, firstElectron->shFracInnerLayer());
 }
 
-void TestElectronReader::testCiCElectronIDVeryLooseMC() {
-	CiCElectronID::value IDunderTest = CiCElectronID::eidVeryLooseMC;
-	ASSERT(firstElectron->CiC_ElectronID(IDunderTest));
-}
-
-void TestElectronReader::testCiCElectronIDLooseMC() {
-	CiCElectronID::value IDunderTest = CiCElectronID::eidLooseMC;
-	ASSERT(firstElectron->CiC_ElectronID(IDunderTest));
-}
-
-void TestElectronReader::testCiCElectronIDMediumMC() {
-	CiCElectronID::value IDunderTest = CiCElectronID::eidMediumMC;
-	ASSERT(firstElectron->CiC_ElectronID(IDunderTest));
-}
-
-void TestElectronReader::testCiCElectronIDTightMC() {
-	CiCElectronID::value IDunderTest = CiCElectronID::eidTightMC;
-	ASSERT(firstElectron->CiC_ElectronID(IDunderTest));
-}
-
-void TestElectronReader::testCiCElectronIDSuperTightMC() {
-	CiCElectronID::value IDunderTest = CiCElectronID::eidSuperTightMC;
-	ASSERT(firstElectron->CiC_ElectronID(IDunderTest));
-}
-
-void TestElectronReader::testCiCElectronIDHyperTight1MC() {
-	CiCElectronID::value IDunderTest = CiCElectronID::eidHyperTight1MC;
-	ASSERT(firstElectron->CiC_ElectronID(IDunderTest));
-}
-
-void TestElectronReader::testCiCElectronIDHyperTight2MC() {
-	CiCElectronID::value IDunderTest = CiCElectronID::eidHyperTight2MC;
-	ASSERT(firstElectron->CiC_ElectronID(IDunderTest));
-}
-
-void TestElectronReader::testCiCElectronIDHyperTight3MC() {
-	CiCElectronID::value IDunderTest = CiCElectronID::eidHyperTight3MC;
-	ASSERT(firstElectron->CiC_ElectronID(IDunderTest));
-}
-
-void TestElectronReader::testCiCElectronIDHyperTight4MC() {
-	CiCElectronID::value IDunderTest = CiCElectronID::eidHyperTight4MC;
-	ASSERT(firstElectron->CiC_ElectronID(IDunderTest));
-}
-
 void TestElectronReader::testPFRelIso03() {
 	ASSERT_EQUAL_DELTA(0.0137179, firstElectron->pfRelativeIsolation(0.3), 0.0000001);
 }
@@ -157,16 +112,6 @@ cute::suite make_suite_TestElectronReader() {
 	s.push_back(CUTE_SMEMFUN(TestElectronReader, testFirstElectronCharge));
 	s.push_back(CUTE_SMEMFUN(TestElectronReader, testFirstElectronD0));
 	s.push_back(CUTE_SMEMFUN(TestElectronReader, testShFracInnerHits));
-
-	s.push_back(CUTE_SMEMFUN(TestElectronReader, testCiCElectronIDVeryLooseMC));
-	s.push_back(CUTE_SMEMFUN(TestElectronReader, testCiCElectronIDLooseMC));
-	s.push_back(CUTE_SMEMFUN(TestElectronReader, testCiCElectronIDMediumMC));
-	s.push_back(CUTE_SMEMFUN(TestElectronReader, testCiCElectronIDTightMC));
-	s.push_back(CUTE_SMEMFUN(TestElectronReader, testCiCElectronIDSuperTightMC));
-	s.push_back(CUTE_SMEMFUN(TestElectronReader, testCiCElectronIDHyperTight1MC));
-	s.push_back(CUTE_SMEMFUN(TestElectronReader, testCiCElectronIDHyperTight2MC));
-	s.push_back(CUTE_SMEMFUN(TestElectronReader, testCiCElectronIDHyperTight3MC));
-	s.push_back(CUTE_SMEMFUN(TestElectronReader, testCiCElectronIDHyperTight4MC));
 
 	s.push_back(CUTE_SMEMFUN(TestElectronReader, testPFRelIso03));
 	s.push_back(CUTE_SMEMFUN(TestElectronReader, testPFRelIso04));

--- a/test/TestElectronReader.h
+++ b/test/TestElectronReader.h
@@ -34,15 +34,6 @@ public:
 	void testFirstElectronCharge();
 	void testFirstElectronD0();
 	void testShFracInnerHits();
-	void testCiCElectronIDVeryLooseMC();
-	void testCiCElectronIDLooseMC();
-	void testCiCElectronIDMediumMC();
-	void testCiCElectronIDTightMC();
-	void testCiCElectronIDSuperTightMC();
-	void testCiCElectronIDHyperTight1MC();
-	void testCiCElectronIDHyperTight2MC();
-	void testCiCElectronIDHyperTight3MC();
-	void testCiCElectronIDHyperTight4MC();
 
 	void testPFRelIso03();
 	void testPFRelIso04();

--- a/test/TestObjectFactory.cpp
+++ b/test/TestObjectFactory.cpp
@@ -114,10 +114,6 @@ ElectronPointer TestObjectFactory::goodCaloElectron() {
 	electron->setNumberOfMissingInnerLayerHits(0);
 	electron->setDCotThetaToNextTrack(0.5);
 	electron->setDistToNextTrack(0.5);
-	int passId = 0;
-	ElectronID::value IDunderTest = ElectronID::CiCHyperTight1MC;
-	passId = passId | 1 << (int) IDunderTest;
-	electron->setCompressedCiCElectronID(passId);
 
 	assert(electron->relativeIsolation() > 0.1);
 	return electron;
@@ -235,10 +231,6 @@ ElectronPointer TestObjectFactory::goodLooseElectron() {
 	looseElectron->setNumberOfMissingInnerLayerHits(0);
 	looseElectron->setD0(0);
 	looseElectron->setSuperClusterEta(0);
-	int passId = 0;
-	CiCElectronID::value IDunderTest = CiCElectronID::eidLooseMC;
-	passId = passId | 1 << (int) IDunderTest;
-	looseElectron->setCompressedCiCElectronID(passId);
 
 	return looseElectron;
 }
@@ -250,11 +242,8 @@ ElectronPointer TestObjectFactory::badLooseElectronNoID() {
 	badLooseElectronNoID->setEcalIsolation(0.3);
 	badLooseElectronNoID->setTrackerIsolation(0.4);
 	badLooseElectronNoID->setSigmaIEtaIEta(0.009 + 2);
-	//CIC ID
-	badLooseElectronNoID->setCompressedCiCElectronID(0);
 
 	assert(badLooseElectronNoID->VBTF_WP95_ElectronID() == false);
-	assert(badLooseElectronNoID->passesElectronID(ElectronID::CiCLooseMC) == false);
 
 	return badLooseElectronNoID;
 }
@@ -265,7 +254,6 @@ ElectronPointer TestObjectFactory::badElectronNoID() {
 	badElectronNoID->setEcalIsolation(0.3);
 	badElectronNoID->setTrackerIsolation(0.4);
 	badElectronNoID->setSigmaIEtaIEta(0.009 + 2);
-	badElectronNoID->setCompressedCiCElectronID(0);
 
 	assert(badElectronNoID->VBTF_WP70_ElectronID() == false);
 


### PR DESCRIPTION
Self-explanatory. Has been tested on 53X ntuples without CiC id being stored.
