### PR TITLE
Updated python/DataSetInfo_8TeV.py

### DIFF
--- a/python/DataSetInfo_8TeV.py
+++ b/python/DataSetInfo_8TeV.py
@@ -21,7 +21,7 @@ datasetInfo = {}
 #if using the designated subset:
 datasetInfo['TTJet'] = {"cross-section": 225.197, "NumberOfProcessedEvents":6920475}
 datasetInfo['WJetsToLNu'] = {"cross-section": 36257.2, "NumberOfProcessedEvents":57708550}
-datasetInfo['W1Jet'] = {"cross-section":  5400.0, "NumberOfProcessedEvents":23140779 }
+datasetInfo['W1Jet'] = {"cross-section": 5400.0, "NumberOfProcessedEvents":23140779 }
 datasetInfo['W2Jets'] = {"cross-section": 1750.0, "NumberOfProcessedEvents":34041404}
 datasetInfo['W3Jets'] = {"cross-section": 519.0, "NumberOfProcessedEvents":15536443}
 datasetInfo['W4Jets'] = {"cross-section": 214.0, "NumberOfProcessedEvents":13370904}
@@ -115,7 +115,7 @@ datasetInfo['Zprime_M750GeV_W7500MeV'] = {"cross-section": 50, "NumberOfProcesse
 datasetInfo['Zprime_M1000GeV_W10GeV'] = {"cross-section": 50, "NumberOfProcessedEvents":0}
 datasetInfo['Zprime_M1000GeV_W100GeV'] = {"cross-section": 50, "NumberOfProcessedEvents":0}
 datasetInfo['Zprime_M1250GeV_W12500MeV'] = {"cross-section": 50, "NumberOfProcessedEvents":0}
-atasetInfo['Zprime_M1500GeV_W15GeV'] = {"cross-section": 50, "NumberOfProcessedEvents":0}
+datasetInfo['Zprime_M1500GeV_W15GeV'] = {"cross-section": 50, "NumberOfProcessedEvents":0}
 datasetInfo['Zprime_M1500GeV_W150GeV'] = {"cross-section": 50, "NumberOfProcessedEvents":0}
 datasetInfo['Zprime_M2000GeV_W20GeV'] = {"cross-section": 50, "NumberOfProcessedEvents":0}
 datasetInfo['Zprime_M2000GeV_W200GeV'] = {"cross-section": 50, "NumberOfProcessedEvents":0}


### PR DESCRIPTION
Reference: BristolTopGroup/AnalysisSoftware/#25
Updated the NumberOfProcessedEvents for each sample.
Checked the cross-sections, some were different but I left them unchanged, as explained in the commit message.
Almost moved the unused samples for this year to the end of the file.
