### PR TITLE
Checking of sample names and uncommenting luminosity weighting.

### DIFF
--- a/bin/Analysis.cpp
+++ b/bin/Analysis.cpp
@@ -121,7 +121,7 @@ void Analysis::initiateEvent() {
 	weight = 1.;
 
 	if (!currentEvent->isRealData()) {
-		//weight = weights->getWeight(currentEvent->getDataType());
+		weight = weights->getWeight(currentEvent->getDataType());
 		//TODO: fix this dirty little thing
 		pileUpWeight = weights->reweightPileUp(currentEvent->getTrueNumberOfVertices().at(1));
 		weight *= pileUpWeight;

--- a/interface/DataTypes.h
+++ b/interface/DataTypes.h
@@ -49,6 +49,7 @@ enum value {
 	QCD_EMEnriched_Pt170_250,
 	QCD_EMEnriched_Pt250_350,
 	QCD_EMEnriched_Pt350,
+	QCD_MuEnrichedPt15_Pt_20, 
 	QCD_MuEnrichedPt5_Pt15to20,
 	QCD_MuEnrichedPt5_Pt20to30,
 	QCD_MuEnrichedPt5_Pt30to50,
@@ -154,6 +155,7 @@ const boost::array<std::string, DataType::NUMBER_OF_DATA_TYPES> names = { {
 		"QCD_Pt_170_250_EMEnriched", //
 		"QCD_Pt_250_350_EMEnriched", //
 		"QCD_Pt_350_EMEnriched", //
+		"QCD_Pt_20_MuEnrichedPt_15", //
 		"QCD_Pt-15to20_MuEnrichedPt5", //
 		"QCD_Pt-20to30_MuEnrichedPt5", //
 		"QCD_Pt-30to50_MuEnrichedPt5", //

--- a/python/DataSetInfo_8TeV.py
+++ b/python/DataSetInfo_8TeV.py
@@ -49,8 +49,7 @@ datasetInfo['QCD_Pt_170_250_EMEnriched'] = {"cross-section": 30990.0 * 0.148, "N
 datasetInfo['QCD_Pt_250_350_EMEnriched'] = {"cross-section": 4250.0 * 0.131, "NumberOfProcessedEvents":34502346}
 datasetInfo['QCD_Pt_350_EMEnriched'] = {"cross-section": 810.0 * 0.11, "NumberOfProcessedEvents":33478691}
 
-datasetInfo['QCD_Pt_20_MuEnrichedPt-15'] = {"cross-section": 3.64e8 * 3.7e-4, "NumberOfProcessedEvents":21484326}
-
+datasetInfo['QCD_Pt_20_MuEnrichedPt_15'] = {"cross-section": 3.64e8 * 3.7e-4, "NumberOfProcessedEvents":21484326}
 datasetInfo['QCD_Pt-15to20_MuEnrichedPt5'] = {"cross-section": 7.022e8 * 0.0039, "NumberOfProcessedEvents":1722678}
 datasetInfo['QCD_Pt-20to30_MuEnrichedPt5'] = {"cross-section": 2.87e8 * 0.0065, "NumberOfProcessedEvents":8486893}
 datasetInfo['QCD_Pt-30to50_MuEnrichedPt5'] = {"cross-section": 6.609e7 * 0.0122, "NumberOfProcessedEvents":8928999}
@@ -133,6 +132,8 @@ datasetInfo['TTJets175'] = {"cross-section": 157.5, "NumberOfProcessedEvents":15
 datasetInfo['TTJets178'] = {"cross-section": 157.5, "NumberOfProcessedEvents":1648519}
 datasetInfo['TTJets181'] = {"cross-section": 157.5, "NumberOfProcessedEvents":1665350}
 datasetInfo['TTJets184'] = {"cross-section": 157.5, "NumberOfProcessedEvents":1671859}
+
+datasetInfo['QCD_Pt-20_MuEnrichedPt-15'] = {"cross-section": 3.64e8 * 3.7e-4, "NumberOfProcessedEvents":25080199}
 
 datasetInfo['QCD_Pt-20to30_BCtoE'] = {"cross-section": 0.2355e9 * 0.00046, "NumberOfProcessedEvents":2081560}
 datasetInfo['QCD_Pt-30to80_BCtoE'] = {"cross-section": 0.0593e9 * 0.00234, "NumberOfProcessedEvents":2013126}


### PR DESCRIPTION
...ython/DataSetInfo_8TeV.py.

Uncommented the line which applies the luminosity weights to monte carlo in bin/Analysis.cpp.
