### PR TITLE
Added license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,15 @@
+Copyright (C) 2011 University of Bristol - Particle Physics Group
+
+University of Bristol - Particle Physics Group can be contacted at: particle-physics@bristol.ac.uk
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
Copyright © 2011-2014 University of Bristol — Particle Physics Group

University of Bristol - Particle Physics Group can be contacted at: particle-physics@bristol.ac.uk

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

```
http://www.apache.org/licenses/LICENSE-2.0
```

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
# 

I hope everyone (@greg-heath @jjacob @joel-goldstein @senkin @EmyrClement ) is happy with the wording.
I plan to add this to our other projects as well.
