### PR TITLE
Use fabs explcitily when it matters.

### DIFF
--- a/src/Analysers/HLTriggerTurnOnAnalyser.cpp
+++ b/src/Analysers/HLTriggerTurnOnAnalyser.cpp
@@ -68,7 +68,7 @@ void HLTriggerTurnOnAnalyser::analyse(const EventPtr event) {
 	}
 
 	//all jets in the v2 nTuples have the following cuts applied:
-	//pt > 20 & abs(eta) < 2.5 && loose ID
+	//pt > 20 & fabs(eta) < 2.5 && loose ID
 	JetCollection jets = event->Jets();
 
 	JetCollection cleanedJets, cleanedBJets;

--- a/src/BTagWeight.cpp
+++ b/src/BTagWeight.cpp
@@ -236,7 +236,7 @@ double BTagWeight::getBScaleFactor(const JetPointer jet, double uncertaintyFacto
 	double sf_error(0);
 	//these numbers are for CSVM only
 	double pt = jet->pt();
-	double eta = abs(jet->eta());
+	double eta = fabs(jet->eta());
 
 	if (Globals::energyInTeV == 8) { // 2012 btag scale factors
 		// From https://twiki.cern.ch/twiki/pub/CMS/BtagPOG/SFb-pt_WITHttbar_payload_EPS13.txt,
@@ -368,7 +368,7 @@ double BTagWeight::getAverageUDSGScaleFactor(const JetCollection jets) const {
 
 double BTagWeight::getUDSGScaleFactor(const JetPointer jet) const {
 	double pt = jet->pt();
-	double eta = abs(jet->eta());
+	double eta = fabs(jet->eta());
 	double SF_udsg_mean(0), SF_udsg_min(0), SF_udsg_max(0);
 
 	if (Globals::energyInTeV == 8) { // 2012

--- a/src/RecoObjects/Electron.cpp
+++ b/src/RecoObjects/Electron.cpp
@@ -352,10 +352,10 @@ double Electron::pfRelativeIsolation(double coneSize, bool deltaBetaCorrection) 
 
 double Electron::pfRelativeIsolationRhoCorrected() const {
 /*	//https://twiki.cern.ch/twiki/bin/view/CMS/EgammaEARhoCorrection#Isolation_cone_R_0_3
-//	2.0<abs(eta)<2.2 	Aeff(NH) = 0.023 +/- 0.001 	Aeff(gamma) = 0.089 +/- 0.002 	Aeff(gamma+NH) = 0.11 +/- 0.003
-//	2.2<abs(eta)<2.3 	Aeff(NH) = 0.023 +/- 0.002 	Aeff(gamma) = 0.092 +/- 0.004 	Aeff(gamma+NH) = 0.12 +/- 0.004
-//	2.3<abs(eta)<2.4 	Aeff(NH) = 0.021 +/- 0.002 	Aeff(gamma) = 0.097 +/- 0.004 	Aeff(gamma+NH) = 0.12 +/- 0.005
-//	abs(eta)>2.4 	Aeff(NH) = 0.021 +/- 0.003 	Aeff(gamma) = 0.11 +/- 0.004 	Aeff(gamma+NH) = 0.13 +/- 0.006
+//	2.0<fabs(eta)<2.2 	Aeff(NH) = 0.023 +/- 0.001 	Aeff(gamma) = 0.089 +/- 0.002 	Aeff(gamma+NH) = 0.11 +/- 0.003
+//	2.2<fabs(eta)<2.3 	Aeff(NH) = 0.023 +/- 0.002 	Aeff(gamma) = 0.092 +/- 0.004 	Aeff(gamma+NH) = 0.12 +/- 0.004
+//	2.3<fabs(eta)<2.4 	Aeff(NH) = 0.021 +/- 0.002 	Aeff(gamma) = 0.097 +/- 0.004 	Aeff(gamma+NH) = 0.12 +/- 0.005
+//	fabs(eta)>2.4 	Aeff(NH) = 0.021 +/- 0.003 	Aeff(gamma) = 0.11 +/- 0.004 	Aeff(gamma+NH) = 0.13 +/- 0.006
 
 	if(coneSize != 0.3){
 		//TODO: put exception or warning

--- a/src/RecoObjects/Muon.cpp
+++ b/src/RecoObjects/Muon.cpp
@@ -557,7 +557,7 @@ double Muon::getEfficiencyCorrection(bool qcd, int muon_scale_factor_systematic,
 					trigger_correction = 0.9804174981053351; // given for pt '140_500' in pickle file
 				}
 			}
-		} else if ((abs(muEta) >= 0.9 && abs(muEta) < 1.2)) { // 'ptabseta0.9-1.2' in pickle file
+		} else if ((fabs(muEta) >= 0.9 && fabs(muEta) < 1.2)) { // 'ptabseta0.9-1.2' in pickle file
 			if ((10 <= pt()) && (pt() < 20)) {
 				switch (muon_scale_factor_systematic) {
 				case -1:
@@ -738,7 +738,7 @@ double Muon::getEfficiencyCorrection(bool qcd, int muon_scale_factor_systematic,
 					trigger_correction = 0.9712789619617556; // given for pt '140_500' in pickle file
 				}
 			}
-		} else if ((abs(muEta) >= 1.2 && abs(muEta) < 2.1)) { // 'ptabseta1.2-2.1' in pickle file
+		} else if ((fabs(muEta) >= 1.2 && fabs(muEta) < 2.1)) { // 'ptabseta1.2-2.1' in pickle file
 			if ((10 <= pt()) && (pt() < 20)) {
 				switch (muon_scale_factor_systematic) {
 				case -1:
@@ -919,7 +919,7 @@ double Muon::getEfficiencyCorrection(bool qcd, int muon_scale_factor_systematic,
 					trigger_correction = 0.9941686682904833; // given for pt '140_500' in pickle file
 				}
 			}
-		} else if (abs(muEta) >= 2.1 && abs(muEta) <= 2.4) { // 'ptabseta2.1-2.4' in pickle file. Note: Trigger scale factors only provided up to absolute eta of 2.1 in the link above, so I have used the same as for the 1.2 to 2.1 eta range.
+		} else if (fabs(muEta) >= 2.1 && fabs(muEta) <= 2.4) { // 'ptabseta2.1-2.4' in pickle file. Note: Trigger scale factors only provided up to absolute eta of 2.1 in the link above, so I have used the same as for the 1.2 to 2.1 eta range.
 			if ((10 <= pt()) && (pt() < 20)) {
 				switch (muon_scale_factor_systematic) {
 				case -1:


### PR DESCRIPTION
This removes the gap in the muon eta distribution seen in 8 TeV:

![image](https://cloud.githubusercontent.com/assets/4438699/3983524/d7637350-287f-11e4-8f4c-ae78f424d1cb.png)
