### PR TITLE
fixing travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ env:
     - ROOT=6-00-00
   global:
     - CLANG_VERSION=3.6
+    - GCC_VERSION=4.9
+    - BOOST_VERSION=1.55
 
 before_install: source ci/before_install.sh
 install: source ci/install.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ set(CMAKE_BUILD_TYPE Release)
 set(CMAKE_CXX_FLAGS "-O3 -std=c++11")
 # first attempt to make cmake work again on OS X
 if((CMAKE_CXX_COMPILER_ID STREQUAL "Clang") AND (APPLE))
+	MESSAGE(STATUS "** std library for clang: libc++")
 	set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -stdlib=libc++")
 endif()
 #Adding files to compile

--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -6,7 +6,7 @@
 
 #set -e
 sudo add-apt-repository --yes ppa:kalakris/cmake
-# add repositories for gcc 4.8 and clang $CLANG_VERSION (set in .travis.yml)
+# add repositories for gcc ${GCC_VERSION} and clang $CLANG_VERSION (set in .travis.yml)
 sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
 sudo add-apt-repository --yes 'deb http://llvm.org/apt/precise/ llvm-toolchain-precise main'
 sudo add-apt-repository --yes 'deb http://ppa.launchpad.net/boost-latest/ppa/ubuntu precise main'
@@ -14,4 +14,4 @@ wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
 # Needed because sometimes travis' repositories get out of date
 sudo apt-get update -q
 # Install the dependencies we need
-time sudo apt-get -q install cmake clang-${CLANG_VERSION} libclang-${CLANG_VERSION}-dev gcc-4.8 g++-4.8 boost1.55
+time sudo apt-get -q install cmake clang-${CLANG_VERSION} libclang-${CLANG_VERSION}-dev gcc-${GCC_VERSION} g++-${GCC_VERSION} boost${BOOST_VERSION}

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -18,9 +18,27 @@ source root/bin/thisroot.sh
 root -l -q
 
 # setup newer compilers ( we need gcc >= 4.7 for c++11
-sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50;
-sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50;
-sudo update-alternatives --set gcc /usr/bin/gcc-4.8; sudo update-alternatives --set g++ /usr/bin/g++-4.8;
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_VERSION} 50;
+sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${GCC_VERSION} 50;
+sudo update-alternatives --set gcc /usr/bin/gcc-${GCC_VERSION}; 
+sudo update-alternatives --set g++ /usr/bin/g++-${GCC_VERSION};
+
+sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${CLANG_VERSION} 50;
+sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${CLANG_VERSION} 50;
+sudo update-alternatives --set clang /usr/bin/clang-${CLANG_VERSION};
+sudo update-alternatives --set clang++ /usr/bin/clang++-${CLANG_VERSION};
+
+export CC=/usr/bin/clang-${CLANG_VERSION};
+export CXX=/usr/bin/clang++-${CLANG_VERSION};
+# check version
+echo "g++ version:"
+g++ --version
+echo "clang version:"
+clang --version
+which clang
+echo "using CXX: ${CXX}"
+
+ls -lah /usr/bin/ | grep clang
 
 cmake CMakelists.txt
 make


### PR DESCRIPTION
For issue #124 
 - [ ] ```cc1plus: error: unrecognized command line option ‘-std=c++11’```
 - [ ] ```In file included from /usr/include/boost/config/select_stdlib_config.hpp:18:
/usr/lib/gcc/x86_64-linux-gnu/4.9/../../../../include/c++/4.9/cstddef:51:11: error:
no member named 'max_align_t' in the global namespace
using ::max_align_t;
~~^
1 error generated.```
 - [ ] ```The C compiler identification is Clang 3.4.0``` should be 3.6!!`

clang 3.6 installation pulls gcc 4.9 but cmake is using Clang 3.4 which is not compatible with gcc 4.9!!