### PR TITLE
travis: updated clang 3.6 to 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ compiler:
 
 env:
   matrix:
-    - ROOT=5-34-18
-    - ROOT=6-00-00
+    - ROOT=5-34-25
+    - ROOT=6-02-04
   global:
     - CLANG_VERSION=3.7
     - GCC_VERSION=4.9
@@ -19,5 +19,5 @@ install: source ci/install.sh
 script: bash ci/test.sh
 cache:
   directories: # also works for files ;)
-  - root_5-34-18_python_2.7.tar.gz
-  - root_v6-00-00_python_2.7.tar.gz
+  - root_v5-34-25_python_2.7.tar.gz
+  - root_v6-02-04_python_2.7.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
     - ROOT=5-34-18
     - ROOT=6-00-00
   global:
-    - CLANG_VERSION=3.6
+    - CLANG_VERSION=3.7
     - GCC_VERSION=4.9
     - BOOST_VERSION=1.55
 


### PR DESCRIPTION
Once again the repos we are using no longer contain the currently used clang version (3.6). Hence I've updated it to the last one.
The proper fix for this problem is to have repositories that include the latest of the minor version (3.4, 3.5, 3,6, etc) and include these instead of having the latest and greatest.