### PR TITLE
[MRG] Binned variable analyser upgrade [Run1]

### DIFF
--- a/interface/HistHelpers/HistogramManager.h
+++ b/interface/HistHelpers/HistogramManager.h
@@ -174,6 +174,12 @@ public:
 	void beginDataType(DataType::value type);
 	void endDataType();
 
+	bool contains1D(std::string histname);
+	bool contains2D(std::string histname);
+	bool contains3D(std::string histname);
+
+	bool hasFolder(std::string folder) const;
+
 private:
 
 	void add1DHistogramFolder(std::string folder);

--- a/src/Analysers/Binned_variable_analyser.cpp
+++ b/src/Analysers/Binned_variable_analyser.cpp
@@ -50,24 +50,18 @@ void Binned_variable_analyser::analyse(double variable,
 		double fit_variable_value, double weight, string fit_variable_name) {
 	histMan_->setCurrentHistogramFolder(histogramFolder_);
 	weight_ = weight * prescale_ * scale_;
-	for (unsigned int index = 0; index < variable_.bins.size() + 1; ++index) {
+	for (unsigned int index = 0; index < variable_.bins.size(); ++index) {
 		double upperCut =
-				index < variable_.bins.size() ?
-						variable_.bins.at(index) : 999999.;
-		double lowerCut = index == 0 ? 0. : variable_.bins.at(index - 1);
+				index < variable_.bins.size() - 1 ?
+						variable_.bins.at(index + 1) : 999999.;
+		double lowerCut = variable_.bins.at(index);
 
 		if (variable >= lowerCut && variable < upperCut) { //find right bin
-			string bin =
-					index < variable_.bins.size() ?
-							boost::lexical_cast<string>(
-									variable_.bins.at(index)) :
+			string lower_edge = boost::lexical_cast<string>(variable_.bins.at(index));
+			string upper_edge =
+					index < variable_.bins.size() - 1 ? boost::lexical_cast<string>(variable_.bins.at(index + 1)) :
 							"inf";
-			string previousBin =
-					index == 0 ?
-							"0" :
-							boost::lexical_cast<string>(
-									variable_.bins.at(index - 1));
-			string folder = variable_.name + "_bin_" + previousBin + "-" + bin;
+			string folder = variable_.name + "_bin_" + lower_edge + "-" + upper_edge;
 			histMan_->setCurrentHistogramFolder(
 					histogramFolder_ + "/" + folder);
 			histMan_->H1D_BJetBinned(fit_variable_name)->Fill(
@@ -98,17 +92,12 @@ void Binned_variable_analyser::analyse_correlations(
 void Binned_variable_analyser::createHistograms() {
 	histMan_->setCurrentHistogramFolder(histogramFolder_);
 
-	for (unsigned int index = 0; index < variable_.bins.size() + 1; ++index) {
-		string bin =
-				index < variable_.bins.size() ?
-						boost::lexical_cast<string>(variable_.bins.at(index)) :
-						"inf";
-		string previousBin =
-				index == 0 ?
-						"0" :
-						boost::lexical_cast<string>(
-								variable_.bins.at(index - 1));
-		string folder = variable_.name + "_bin_" + previousBin + "-" + bin;
+	for (unsigned int index = 0; index < variable_.bins.size(); ++index) {
+		string lower_edge = boost::lexical_cast<string>(variable_.bins.at(index));
+		string upper_edge =
+				index < variable_.bins.size() - 1 ? boost::lexical_cast<string>(variable_.bins.at(index + 1)) : "inf";
+
+		string folder = variable_.name + "_bin_" + lower_edge + "-" + upper_edge;
 		histMan_->setCurrentHistogramFolder(histogramFolder_ + "/" + folder);
 		// create all fit variable histograms
 		for (unsigned int i = 0; i < fit_variables_.size(); ++i) {

--- a/src/Analysers/TTbar_plus_X_analyser.cpp
+++ b/src/Analysers/TTbar_plus_X_analyser.cpp
@@ -810,18 +810,18 @@ TTbar_plus_X_analyser::TTbar_plus_X_analyser(HistogramManagerPtr histMan, std::s
 
 	//bins: start is always assumed to be 0 and the last is read as > X
 	//MET bins:
-	// very old: 25, 45, 70, 100, 150, inf
 	// old: [0.0, 31.0, 58.0, 96.0, 142.0, 191.0, inf]
 	// new: [0.0, 27.0, 52.0, 87.0, 129.0, 171.0, inf]
+	metBins_.push_back(0.);
 	metBins_.push_back(27.);
 	metBins_.push_back(52.);
 	metBins_.push_back(87.);
 	metBins_.push_back(129.);
 	metBins_.push_back(171.);
 	//HT:
-	// very old: 50, 150, 250, 350, 450, 650, 1100, inf
 	// old: [0.0, 190.0, 225.0, 262.0, 302.0, 345.0, 392.0, 445.0, 501.0, 562.0, 623.0, 689.0, 766.0, inf]
 	// new: [0.0, 187.0, 217.0, 250.0, 287.0, 327.0, 369.0, 414.0, 464.0, 517.0, 575.0, 634.0, 696.0, 772.0, inf]
+	ht_bins_.push_back(0.);
 	ht_bins_.push_back(187.0);
 	ht_bins_.push_back(217.0);
 	ht_bins_.push_back(250.0);
@@ -837,9 +837,9 @@ TTbar_plus_X_analyser::TTbar_plus_X_analyser(HistogramManagerPtr histMan, std::s
 	ht_bins_.push_back(772.0);
 
 	//ST:
-	// very old: 150, 250, 350, 450, 550, 750, 1250, inf new: 350 & 400 & 450 & 500 & 580 & 700 & inf
 	// old: [0.0, 285.0, 329.0, 376.0, 428.0, 484.0, 544.0, 609.0, 678.0, 751.0, 830.0, 911.0, 1028.0, inf]
 	// new: [0.0, 281.0, 324.0, 367.0, 415.0, 466.0, 521.0, 581.0, 645.0, 714.0, 783.0, 861.0, 946.0, inf]
+	st_bins_.push_back(0.);
 	st_bins_.push_back(281.0);
 	st_bins_.push_back(324.0);
 	st_bins_.push_back(367.0);
@@ -854,16 +854,16 @@ TTbar_plus_X_analyser::TTbar_plus_X_analyser(HistogramManagerPtr histMan, std::s
 	st_bins_.push_back(946.0);
 
 	//MT:
-	// very old: 0, 40, 65, 85, 150, inf
 	// old: [0.0, 28.0, 66.0, inf]
 	// new: [0.0, 23.0, 58.0, inf]
+	mt_bins_.push_back(0.);
 	mt_bins_.push_back(23.0);
 	mt_bins_.push_back(58.0);
 
 	//WPT:
-	// very old: 0, 40, 70, 100, 130, 170 inf
 	// old: [0.0, 31.0, 59.0, 88.0, 118.0, 151.0, 187.0, 227.0, 267.0, inf]
 	// new: [0.0, 27.0, 52.0, 78.0, 105.0, 134.0, 165.0, 198.0, 235.0, inf]
+	wpt_bins_.push_back(0.);
 	wpt_bins_.push_back(27.0);
 	wpt_bins_.push_back(52.0);
 	wpt_bins_.push_back(78.0);

--- a/src/HistHelpers/HistogramManager.cpp
+++ b/src/HistHelpers/HistogramManager.cpp
@@ -673,5 +673,22 @@ unsigned int HistogramManager::size3D(DataType::value type) const {
 	}
 	return size;
 }
+
+bool HistogramManager::contains1D(std::string histname) {
+	return collection1D[currentHistogramFolder][currentDataType]->contains(histname);
+}
+
+bool HistogramManager::contains2D(std::string histname) {
+	return collection2D[currentHistogramFolder][currentDataType]->contains(histname);
+}
+
+bool HistogramManager::contains3D(std::string histname) {
+	return collection3D[currentHistogramFolder][currentDataType]->contains(histname);
+}
+
+bool HistogramManager::hasFolder(std::string folder) const {
+	return collection1D.find(folder) != collection1D.end();
+}
+
 } //end namespace BAT
 

--- a/src/Readers/NTupleEventReader.cpp
+++ b/src/Readers/NTupleEventReader.cpp
@@ -75,6 +75,9 @@ NTupleEventReader::NTupleEventReader() :
 		metReaders.at(index) = boost::shared_ptr<METReader>(new METReader(input, (METAlgorithm::value) index));
 	}
 
+	for (unsigned int i = 0; i < DataType::NUMBER_OF_DATA_TYPES; ++i)
+		seenDataTypes.at(i) = false;
+
 }
 
 NTupleEventReader::~NTupleEventReader() {

--- a/test/TestBinnedVariableAnalyser.cpp
+++ b/test/TestBinnedVariableAnalyser.cpp
@@ -1,0 +1,90 @@
+#include <boost/test/unit_test.hpp>
+#include <vector>
+
+#include "../interface/Analysers/Binned_variable_analyser.h"
+#include "../interface/HistHelpers/HistogramManager.h"
+
+using namespace BAT;
+
+struct TestSetup {
+	TestSetup() :
+					histMan(new HistogramManager()),
+					analyser(new Binned_variable_analyser(histMan, "TestBinnedVariableAnalyser")),
+					zero_start_var(),
+					non_zero_start_var(),
+					fit_variable("fit_var", 20, 0.0, 100.),
+					zero_var_bins(),
+					non_zero_var_bins() {
+		boost::array<bool, DataType::NUMBER_OF_DATA_TYPES> seenDataTypes;
+		for (unsigned int i = 0; i < DataType::NUMBER_OF_DATA_TYPES; ++i)
+			seenDataTypes.at(i) = false;
+		seenDataTypes.at(DataType::SingleElectron) = true;
+		histMan->prepareForSeenDataTypes(seenDataTypes);
+		histMan->setCurrentDataType(DataType::SingleElectron);
+		zero_var_bins.push_back(0);
+		zero_var_bins.push_back(1);
+		zero_var_bins.push_back(5);
+		zero_var_bins.push_back(10);
+
+		non_zero_var_bins.push_back(1);
+		non_zero_var_bins.push_back(5);
+		non_zero_var_bins.push_back(10);
+
+		zero_start_var = Variable("zero_start_var", zero_var_bins);
+		non_zero_start_var = Variable("non_zero_start_var", non_zero_var_bins);
+
+	}
+
+	~TestSetup() {
+
+	}
+
+	HistogramManagerPtr histMan;
+	Binned_Variable_analyser_ptr analyser;
+	Variable zero_start_var, non_zero_start_var, fit_variable;
+	std::vector<double> zero_var_bins, non_zero_var_bins;
+};
+BOOST_AUTO_TEST_SUITE (TestBinnedVariableAnalyser)
+BOOST_FIXTURE_TEST_CASE(test_zero_start_var, TestSetup) {
+	analyser->set_variables(zero_start_var, fit_variable);
+	analyser->createHistograms();
+	BOOST_CHECK_EQUAL(histMan->size(), zero_var_bins.size() * 5);
+
+	// this folder should not exist
+	string folder = "TestBinnedVariableAnalyser/" + zero_start_var.name + "_bin_0-0";
+	BOOST_CHECK_EQUAL(histMan->hasFolder(folder), false);
+	// this should be the first valid bin
+	folder = "TestBinnedVariableAnalyser/" + zero_start_var.name + "_bin_0-1";
+	BOOST_CHECK_EQUAL(histMan->hasFolder(folder), true);
+
+	// this should go into the first bin
+	analyser->analyse(0.5, 3, 1.);
+	histMan->setCurrentHistogramFolder(folder);
+	BOOST_CHECK_EQUAL(histMan->H1D("fit_var_0btag")->Integral(), 1);
+}
+
+BOOST_FIXTURE_TEST_CASE(test_non_zero_start_var, TestSetup) {
+	analyser->set_variables(non_zero_start_var, fit_variable);
+	analyser->createHistograms();
+	BOOST_CHECK_EQUAL(histMan->size(), non_zero_var_bins.size() * 5);
+
+	// this folder should not exist
+	string folder = "TestBinnedVariableAnalyser/" + non_zero_start_var.name + "_bin_0-1";
+	BOOST_CHECK_EQUAL(histMan->hasFolder(folder), false);
+	// this should be the first valid bin
+	folder = "TestBinnedVariableAnalyser/" + non_zero_start_var.name + "_bin_1-5";
+	BOOST_CHECK_EQUAL(histMan->hasFolder(folder), true);
+
+	// this should not go anywhere
+	analyser->analyse(0.5, 3, 1.);
+	histMan->setCurrentHistogramFolder(folder);
+	BOOST_CHECK_EQUAL(histMan->H1D("fit_var_0btag")->Integral(), 0);
+
+	// but this should
+	analyser->analyse(4, 3, 1.);
+	histMan->setCurrentHistogramFolder(folder);
+	BOOST_CHECK_EQUAL(histMan->H1D("fit_var_0btag")->Integral(), 1);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+


### PR DESCRIPTION
As asked, this is the modified version of the Binned variable analyser.
I have
 - added some tests to verify the correct behaviour
 - changed the behaviour
 - updated TTbar_plus_X_analyser (we now have to specify the first bin lower edge)

There are still some tests missing:
 - are the folders correctly created?
 - is underflow and overflow treated correctly (we currently throw away underflow!)

BTW: The way the Binned variable analyser is constructed you can add any set of bins in the code but only read the ones you are interested in in the DPS. Long story short: no change was necessary to accomplish this functionality, but in the new implementation no unnecessary histograms are created.