### PR TITLE
Run Analysis Tools over single ntuple in sample

### DIFF
--- a/condor/condor.sh
+++ b/condor/condor.sh
@@ -16,6 +16,7 @@
 # --sample=<valid sample> (TTJet, etc) 
 # --mode=<valid mode of operation> (central, JES_up, etc)
 # --cmssw=53X|73X|74X
+# --splitTTJet
 NOW=$(date +"%d-%m-%Y")
 # remove Analysis.tar in case it exists. We want to ship the latest code!
 if [ -f "Analysis.tar" ]; then
@@ -33,7 +34,7 @@ operation=`BristolAnalysis/Tools/condor/job_mapper "$@" --return_operation`
 energy=`BristolAnalysis/Tools/condor/job_mapper "$@"  --return_energy`
 cmssw_version=`BristolAnalysis/Tools/condor/job_mapper "$@"  --return_cmssw`
 noop=`BristolAnalysis/Tools/condor/job_mapper "$@"  --return_noop`
-
+splitTTJet=`BristolAnalysis/Tools/condor/job_mapper "$@"  --return_splitTTJet`
 job_description="job.description.$NOW"
 cp BristolAnalysis/Tools/condor/job.description.template $job_description;
 # inject all parameters into job.description arguments
@@ -44,13 +45,17 @@ if [ $operation == "test" ] || [ $operation == "single" ]; then
 	
 	mode=`BristolAnalysis/Tools/condor/job_mapper "$@" --return_mode`
 	sample=`BristolAnalysis/Tools/condor/job_mapper "$@" --return_sample`
-	
+
 	set1="--operation=$operation --cores=$cores --mode=$mode --sample=$sample"
-	set2="--sample=$sample --energy=$energy --cmssw=$cmssw_version"
+	set2="--energy=$energy --cmssw=$cmssw_version"
+	n_jobs=`BristolAnalysis/Tools/condor/job_mapper "$@" --return_n_jobs`
 	other_params="$set1 $set2"
-	
+	if [ $splitTTJet == "True" ]; then
+		other_params="$set1 $set2 --splitTTJet"
+	fi
+
 	sed -i "s/%other_params%/${other_params}/g" $job_description
-	sed -i "s/%n_jobs%/1/g" $job_description
+	sed -i "s/%n_jobs%/${n_jobs}/g" $job_description
 	
 fi
 if [ $operation == "single-sample-analysis" ]; then
@@ -63,6 +68,10 @@ if [ $operation == "single-sample-analysis" ]; then
 	other_params="$set1 $set2"
 	n_jobs=`BristolAnalysis/Tools/condor/job_mapper "$@" --return_n_jobs`
 	
+	if [ $splitTTJet == "True" ]; then
+		other_params="$set1 $set2 --splitTTJet"
+	fi
+
 	sed -i "s/%other_params%/${other_params}/g" $job_description
 	sed -i "s/%n_jobs%/${n_jobs}/g" $job_description
 fi
@@ -74,6 +83,10 @@ if [ $operation == "analysis" ]; then
 	set2="--energy=$energy --cmssw=$cmssw_version"
 	other_params="$set1 $set2"
 	n_jobs=`BristolAnalysis/Tools/condor/job_mapper "$@" --return_n_jobs`
+	
+	if [ $splitTTJet == "True" ]; then
+		other_params="$set1 $set2 --splitTTJet"
+	fi
 	
 	sed -i "s/%other_params%/${other_params}/g" $job_description
 	sed -i "s/%n_jobs%/${n_jobs}/g" $job_description

--- a/condor/job.sh
+++ b/condor/job.sh
@@ -37,7 +37,11 @@ while [ $local_process -lt $range_for_loop ] ; do
 	analysisMode=`BristolAnalysis/Tools/condor/job_mapper "$@" --return_mode --process $local_process`
 	energy=`BristolAnalysis/Tools/condor/job_mapper "$@"  --return_energy`
 	operation=`BristolAnalysis/Tools/condor/job_mapper "$@" --return_operation`
+	splitTTJet=`BristolAnalysis/Tools/condor/job_mapper "$@" --return_splitTTJet`
+	ntupleToProcess=`BristolAnalysis/Tools/condor/job_mapper "$@" --return_ntupleToProcess --process $local_process`
+
 	echo "I will run sample=${sample} in mode=${analysisMode} for centre-of-mass energy of ${energy} TeV"
+	echo "Analysing ntuple number "$ntupleToProcess
 
 	python_config=master_PHYS14_cfg.py
 	if [ $energy -eq 7 ]; then
@@ -51,7 +55,11 @@ while [ $local_process -lt $range_for_loop ] ; do
 	fi
 
 	log_file=${sample}_${analysisMode}_${energy}TeV_${cmssw_version}.log
-	sample="$sample" analysisMode="$analysisMode" ${exe} ${toolsFolder}python/${python_config} ${TQAFPath} &> $log_file &
+	if [ $ntupleToProcess -ne -1 ]; then
+		log_file=${sample}_${analysisMode}_${ntupleToProcess}_${energy}TeV_${cmssw_version}.log
+	fi
+
+	sample="$sample" analysisMode="$analysisMode" ntupleToProcess=$ntupleToProcess ${exe} ${toolsFolder}python/${python_config} ${TQAFPath} &> $log_file &
 	
 	let local_process+=1
 done

--- a/condor/job_mapper
+++ b/condor/job_mapper
@@ -26,6 +26,7 @@
  --sample=<valid sample> (TTJet, etc) 
  --mode=<valid mode of operation> (central, JES_up, etc)
  --cmssw=53X|73X|74X|75X
+ --splitTTJet
  
  defining return values:
  return_<parameter>: script will return the specified parameter (e.g. return_mode returns the mode)
@@ -49,9 +50,15 @@ samples_7TeV = analysis_info.datasets_7TeV.keys()
 samples_8TeV = analysis_info.datasets_8TeV.keys()
 samples_13TeV = analysis_info.datasets_13TeV.keys()
 
-def build_matrix(energy, chosen_sample = None):
+inputDir_7TeV = analysis_info.datasets_7TeV
+inputDir_8TeV = analysis_info.datasets_8TeV
+inputDir_13TeV = analysis_info.datasets_13TeV
+
+def build_matrix(energy, chosen_sample = None, chosen_mode = None, splitTTJet = False):
     global analysis_modes
     analysis_modes_ = copy(analysis_modes)
+    if chosen_mode != None:
+        analysis_modes_ = [ chosen_mode ]
     samples = None
     if energy == 7:
         samples = samples_7TeV
@@ -61,17 +68,38 @@ def build_matrix(energy, chosen_sample = None):
         samples = samples_13TeV
         analysis_modes_ = analysis_info.analysis_modes_13TeV
     result = []
+
     if chosen_sample:
         if not chosen_sample in samples:
             sys.exit("ERROR Trying to run unknown sample '%s'" % options.sample)
         for mode in analysis_modes_:
-            result.append((chosen_sample, mode))
+            if splitTTJet and chosen_sample == 'TTJet':
+                for ntupleIndex in range(1,numberOfInputFiles(chosen_sample,energy)+1):
+                    result.append((chosen_sample, mode,ntupleIndex))
+            else:
+                result.append((chosen_sample, mode, -1))
         return result, [chosen_sample]
     else:
         for sample in samples:
             for mode in analysis_modes_:
-                result.append((sample, mode))
+                if splitTTJet and sample is 'TTJet':
+                    for ntupleIndex in range(1,numberOfInputFiles(sample,energy)+1):
+                        result.append((sample, mode,ntupleIndex))
+                else:
+                    result.append((sample, mode, -1))
     return result, samples
+
+def numberOfInputFiles(sample, energy):
+    inputDir = ''
+    if energy == 7:
+        inputDir = inputDir_7TeV
+    if energy == 8:
+        inputDir = inputDir_8TeV
+    if energy == 13:
+        inputDir = inputDir_13TeV
+    inputDir = inputDir[sample][0]
+    inputFiles = os.listdir(inputDir)
+    return len(inputFiles)
 
 def main(options, args = []):
     if options.operation == 'test':
@@ -95,18 +123,26 @@ def main(options, args = []):
         return options.process
     if options.return_operation:
         return options.operation
+    if options.return_splitTTJet:
+        return options.splitTTJet
     # now the dynamic options
     matrix, samples = None, None
     if options.operation == 'single-sample-analysis':
-        matrix, samples = build_matrix(options.energy, options.sample)
+        matrix, samples = build_matrix(options.energy, chosen_sample = options.sample, splitTTJet = options.splitTTJet)
+    elif options.operation == 'single':
+        matrix, samples = build_matrix(options.energy, chosen_sample = options.sample, chosen_mode = options.mode, splitTTJet = options.splitTTJet)
     else:
-        matrix, samples = build_matrix(options.energy)
+        matrix, samples = build_matrix(options.energy, splitTTJet = options.splitTTJet)
+
     if options.return_n_jobs:
         if options.operation == 'test' or options.operation == 'single':
-            return 1
+            if options.operation == 'single' and options.splitTTJet:
+                return numberOfInputFiles(options.sample, options.energy)
+            else:
+                return 1
         else:
             return len(matrix)
-    
+
     if options.return_sample:
         if options.sample:
             if not options.sample in samples:
@@ -114,7 +150,18 @@ def main(options, args = []):
             return options.sample
         else:
             return matrix[options.process][0]
-    
+
+    if options.return_nInputNtuples:
+        if options.sample:
+            if not options.sample in samples:
+                sys.exit("ERROR Trying to run unknown sample '%s'" % options.sample)
+            return numberOfInputFiles(options.sample, options.energy)
+        else:
+            return -1
+
+    if options.return_ntupleToProcess:
+        return matrix[options.process][2]
+
     if options.return_mode:
         if options.mode:
             if not options.mode in analysis_modes:
@@ -144,10 +191,14 @@ def parse_args(parameters = []):
     parser.add_option( '--energy', dest = 'energy', 
                        help = 'centre-of-mass energy (7|8|13|14 TeV)',
                        type = int )
+    parser.add_option("--splitTTJet", action = "store_true", dest = "splitTTJet", default = False,
+                          help = "Whether to split up TTJet sample, and assigne one process per ntuple" )
     parser.add_option("--noop", action = "store_true", dest = "noop",
                           help = "Returns the noop flag" )
     parser.add_option("--return_sample", action = "store_true", dest = "return_sample",
                           help = "Returns the sample from the map based on process" )
+    parser.add_option("--return_nInputNtuples", action = "store_true", dest = "return_nInputNtuples",
+                          help = "Returns the number of ntuples for a sample from the map based on process" )
     parser.add_option("--return_mode", action = "store_true", dest = "return_mode",
                           help = "Returns the analysis mode from the map based on process" )
     parser.add_option("--return_cmssw", action = "store_true", dest = "return_cmssw",
@@ -164,7 +215,11 @@ def parse_args(parameters = []):
                           help = "Returns the operation" )
     parser.add_option("--return_noop", action = "store_true", dest = "return_noop",
                           help = "Returns the noop flag" )
-    
+    parser.add_option("--return_splitTTJet", action = "store_true", dest = "return_splitTTJet",
+                          help = "Returns the return_splitTTJet flag" )
+    parser.add_option("--return_ntupleToProcess", action = "store_true", dest = "return_ntupleToProcess",
+                          help = "Returns the ntuple number to process if splitting job up" )
+
     options, args = None, None
     if len(parameters) > 0:
         ( options, args ) = parser.parse_args(parameters)

--- a/python/master_PHYS14_cfg.py
+++ b/python/master_PHYS14_cfg.py
@@ -85,7 +85,13 @@ if sample in ['TTJets-mcatnlo','TTJets-powheg']:
         settings['custom_file_suffix'] = suffixes[sample]
     else:
         settings['custom_file_suffix'] = suffixes[sample] + '_' + settings['custom_file_suffix']    
-    
+
+
+# Option to process a single ntuple of a sample rather than all of them
+ntupleToProcess = -1
+if os.environ.has_key('ntupleToProcess'):
+    ntupleToProcess = int(os.environ['ntupleToProcess'])
+
 #File for pile-up re-weighting
 PUFile = toolsFolder + "data/" + settings['PUFile']
 getMuonScaleFactorsFromFile = False
@@ -108,6 +114,10 @@ for setting,value in settings.iteritems():
     print setting, '=', value
 input_folders = datasets[sample]
 filetype = '*.root'
+if ntupleToProcess > 0 :
+    filetype = '*%03d.root' % ntupleToProcess
+    print 'Will only consider ntuple : ',filetype
+    settings['custom_file_suffix'] += str(ntupleToProcess)   
 inputFiles = [path + '/' + filetype for path in input_folders]
 # inputFiles = datasets[sample]
 


### PR DESCRIPTION
AT can now be run over a single file of a sample with the option ntupleToProcess.

The condor submission scripts have also been modified so that (for TTJet sample only at the moment) one job is submitted for each input file of a sample.  e.g. There are currently 10 separate files for the TTJet ntuple, so 10 jobs are submitted.