### PR TITLE
Bug fix to #157

### DIFF
--- a/python/master_PHYS14_cfg.py
+++ b/python/master_PHYS14_cfg.py
@@ -109,17 +109,20 @@ JetSmearingSystematic = settings['JetSmearingSystematic']
 BTagSystematic = settings['BTagSystematic']
 LightTagSystematic = settings['LightTagSystematic']
 custom_file_suffix = settings['custom_file_suffix']
-print 'Parsed config settings:'
-for setting,value in settings.iteritems():
-    print setting, '=', value
+
 input_folders = datasets[sample]
 filetype = '*.root'
 if ntupleToProcess > 0 :
     filetype = '*%03d.root' % ntupleToProcess
     print 'Will only consider ntuple : ',filetype
-    settings['custom_file_suffix'] += str(ntupleToProcess)   
+    settings['custom_file_suffix'] += str(ntupleToProcess)
+    custom_file_suffix = settings['custom_file_suffix']
 inputFiles = [path + '/' + filetype for path in input_folders]
 # inputFiles = datasets[sample]
+
+print 'Parsed config settings:'
+for setting,value in settings.iteritems():
+    print setting, '=', value
 
 #number of events to be processed
 maxEvents = 0# 0 == all


### PR DESCRIPTION
Output files had identical names.  custom_file_suffix was being set in the settings list, but not the global variable that is actually read in by Analysis Tools.
