### PR TITLE
Add output tree for NoBJet Selection.

### DIFF
--- a/interface/Analysers/TTbar_plus_X_analyser.h
+++ b/interface/Analysers/TTbar_plus_X_analyser.h
@@ -34,7 +34,10 @@ public:
 	virtual void analyse(const EventPtr);
 	virtual void createTrees();
 	void createCommonTrees( std::string folder );
+	void createCommonNoBSelectionTrees( std::string folder );
 	void fillCommonTrees(const EventPtr event,  const unsigned int selection, std::string folder );
+	void fillCommonTreesNoBSelection(const EventPtr event,  const unsigned int selectionCriteria, std::string folder );
+	void fillLeptonEfficiencyCorrectionBranches( const EventPtr event, const unsigned int selectionCriteria, const LeptonPointer signalLepton );	
 	virtual void createHistograms() {};
 	void ePlusJetsQcdAnalysis(const EventPtr);
 	void muPlusJetsQcdAnalysis(const EventPtr);


### PR DESCRIPTION
Add a few extra branches where no b jet selection has been applied.  Events still have a lepton and four jets.

Can be used for e.g. nBjet plot starting from 0, checking pileup reweighting with a larger sample etc.