### PR TITLE
B tag efficiencies

### DIFF
--- a/src/Analysers/BTagEfficiencyAnalyser.cpp
+++ b/src/Analysers/BTagEfficiencyAnalyser.cpp
@@ -65,6 +65,23 @@ void BTagEff::analyse(const EventPtr event) {
 	treeMan_->Fill("NBJets", NBJets);
 	treeMan_->Fill("EventWeight", event->weight());
 	treeMan_->Fill("PUWeight", event->PileUpWeight());
+
+	if ( selectionCriteria == SelectionCriteria::ElectronPlusJetsReference ) {
+		double electronEfficiencyCorrection = 1;
+		if ( !event->isRealData() ) {
+			const ElectronPointer signalElectron(boost::static_pointer_cast<Electron>(signalLepton));
+			electronEfficiencyCorrection = signalElectron->getEfficiencyCorrection( 0 );
+		}
+		treeMan_->Fill("ElectronEfficiencyCorrection",electronEfficiencyCorrection);
+	}
+	else if ( selectionCriteria == SelectionCriteria::MuonPlusJetsReference ) {
+		double muonEfficiencyCorrection = 1;
+		if ( !event->isRealData() ) {
+			const MuonPointer signalMuon(boost::static_pointer_cast<Muon>(signalLepton));
+			muonEfficiencyCorrection = signalMuon->getEfficiencyCorrection( 0 );
+		}
+		treeMan_->Fill("MuonEfficiencyCorrection",muonEfficiencyCorrection);
+	}
 }
 
 
@@ -91,5 +108,7 @@ void BTagEff::createTrees() {
 	treeMan_->addBranch("isTight", "F", "Jets" + Globals::treePrefix_, false);
 	treeMan_->addBranch("NJets", "F", "Jets" + Globals::treePrefix_);
 	treeMan_->addBranch("NBJets", "F", "Jets" + Globals::treePrefix_);
+	treeMan_->addBranch("ElectronEfficiencyCorrection", "F", "FitVariables" + Globals::treePrefix_);
+	treeMan_->addBranch("MuonEfficiencyCorrection", "F", "FitVariables" + Globals::treePrefix_);
 }
 /* namespace BAT */

--- a/src/Analysers/BTagEfficiencyAnalyser.cpp
+++ b/src/Analysers/BTagEfficiencyAnalyser.cpp
@@ -108,7 +108,7 @@ void BTagEff::createTrees() {
 	treeMan_->addBranch("isTight", "F", "Jets" + Globals::treePrefix_, false);
 	treeMan_->addBranch("NJets", "F", "Jets" + Globals::treePrefix_);
 	treeMan_->addBranch("NBJets", "F", "Jets" + Globals::treePrefix_);
-	treeMan_->addBranch("ElectronEfficiencyCorrection", "F", "FitVariables" + Globals::treePrefix_);
-	treeMan_->addBranch("MuonEfficiencyCorrection", "F", "FitVariables" + Globals::treePrefix_);
+	treeMan_->addBranch("ElectronEfficiencyCorrection", "F", "Jets" + Globals::treePrefix_);
+	treeMan_->addBranch("MuonEfficiencyCorrection", "F", "Jets" + Globals::treePrefix_);
 }
 /* namespace BAT */

--- a/src/Analysers/TTbar_plus_X_analyser.cpp
+++ b/src/Analysers/TTbar_plus_X_analyser.cpp
@@ -563,8 +563,8 @@ TTbar_plus_X_analyser::TTbar_plus_X_analyser(HistogramManagerPtr histMan, TreeMa
 		hitFitAnalyserMuPlusJetsQCDSelection3toInf_(new HitFitAnalyser(histMan, treeMan, false, histogramFolder + "/MuPlusJets/QCD non iso mu+jets 3toInf/HitFit")), //		
 		likelihoodRecoAnalyserEPlusJetsRefSelection_(new LikelihoodRecoAnalyser(histMan, treeMan, true, histogramFolder + "/EPlusJets/Ref selection/LikelihoodReco")), //
 		likelihoodRecoAnalyserMuPlusJetsRefSelection_(new LikelihoodRecoAnalyser(histMan, treeMan, false, histogramFolder + "/MuPlusJets/Ref selection/LikelihoodReco")), //
-		BTagEffAnalyserEPlusJetsRefSelection_(new BTagEff(histMan, treeMan, histogramFolder + "/EPlusJets/Ref selection/BTagEfficiencies")), //
-		BTagEffAnalyserMuPlusJetsRefSelection_(new BTagEff(histMan, treeMan, histogramFolder + "/MuPlusJets/Ref selection/BTagEfficiencies")), //
+		BTagEffAnalyserEPlusJetsRefSelection_(new BTagEff(histMan, treeMan, histogramFolder + "/EPlusJets/Ref selection NoBSelection/BTagEfficiencies")), //
+		BTagEffAnalyserMuPlusJetsRefSelection_(new BTagEff(histMan, treeMan, histogramFolder + "/MuPlusJets/Ref selection NoBSelection/BTagEfficiencies")), //
 		PileupAnalyserEPlusJetsRefSelection_(new PileupAnalyser(histMan, treeMan, histogramFolder + "/EPlusJets/Ref selection/Pileup")), //
 		PileupAnalyserMuPlusJetsRefSelection_(new PileupAnalyser(histMan, treeMan, histogramFolder + "/MuPlusJets/Ref selection/Pileup")) //
 		{


### PR DESCRIPTION
- Use cleaned jets, as these are now set after the NoB selection, rather than the full selection.
- Consider events passing all selection criteria
- Add scale factors to tree