### PR TITLE
Move generator weights to same tree as unfolding variables.

### DIFF
--- a/src/Analysers/UnfoldingRecoAnalyser.cpp
+++ b/src/Analysers/UnfoldingRecoAnalyser.cpp
@@ -157,7 +157,7 @@ void UnfoldingRecoAnalyser::createTrees() {
 	treeMan_->addBranch("bEta", "F", "Unfolding" + Globals::treePrefix_, false);
 
 	for ( unsigned int i = 0; i < 250; ++i ) {
-		treeMan_->addBranch("genWeight_" + to_string(i), "F", "GeneratorSystematicWeights" + Globals::treePrefix_);
+		treeMan_->addBranch("genWeight_" + to_string(i), "F", "Unfolding" + Globals::treePrefix_);
 	}
 }
 


### PR DESCRIPTION
Move the generator level weights in the Unfolding tree.  This is because changes to the scripts in dps can't seem to handle friend trees. (When looping over events in a tree, friend trees don't seem to function in pyroot, though Tree::Draw does)