### PR TITLE
removed invalid symlink

### DIFF
--- a/external/TopQuarkAnalysis/TopQuarkAnalysis
+++ b/external/TopQuarkAnalysis/TopQuarkAnalysis
@@ -1,1 +1,0 @@
-BristolAnalysis/Tools/external/TopQuarkAnalysis


### PR DESCRIPTION
This symlink is causing problems in the NTP setup and is included in the setup instructions for AS stand-alone. No reason to keep it in the repo.