### PR TITLE
ReHLT samples

### DIFF
--- a/interface/Event.h
+++ b/interface/Event.h
@@ -136,6 +136,7 @@ public:
 	bool isRealData() const;
 	const DataType::value getDataType() const;
 	bool isTTJet(DataType::value type) const;
+	bool isReHLTMC() const;
 	void setDataType(DataType::value type);
 	void setVertices(VertexCollection vertices);
 	void setTracks(TrackCollection tracks);

--- a/src/Event.cpp
+++ b/src/Event.cpp
@@ -136,6 +136,14 @@ bool Event::isTTJet( DataType::value type) const {
 		return false;
 }
 
+bool Event::isReHLTMC() const {
+	return  dataType == DataType::DYJetsToLL_M50 
+	|| dataType == DataType::TTJets_PowhegPythia8
+	|| dataType == DataType::TTJets_amcatnloFXFX
+	|| dataType == DataType::WJetsToLNu
+	|| ( dataType >= DataType::QCD_MuEnriched_15to20 && dataType <= DataType::QCD_MuEnriched_1000toInf);
+}
+
 void Event::setDataType(DataType::value type) {
 	dataType = type;
 }

--- a/src/Readers/NTupleEventReader.cpp
+++ b/src/Readers/NTupleEventReader.cpp
@@ -165,16 +165,21 @@ const EventPtr NTupleEventReader::getNextEvent() {
 		currentEvent->setPassesElectronChannelQCDTrigger( passesElectronChannelTriggerReader->getVariable() );
 		currentEvent->setPassesMuonChannelQCDTrigger( passesMuonChannelTriggerReader->getVariable() );
 	}
-	else {
-		currentEvent->setPassesElectronChannelTrigger( true );
+	else if ( currentEvent->isReHLTMC() ) {
 		// currentEvent->setPassesElectronChannelTrigger( passesElectronChannelMCTriggerReader->getVariable() );
 		// currentEvent->setPassesMuonChannelTrigger( passesMuonChannelMCTriggerReader->getVariable() );
-		// currentEvent->setPassesTkMuonChannelTrigger( passesTkMuonChannelMCTriggerReader->getVariable() );
+		// currentEvent->setPassesTkMuonChannelTrigger( passesTkMuonChannelMCTriggerReader->getVariable() );		
+		currentEvent->setPassesElectronChannelTrigger( true );
+		currentEvent->setPassesMuonChannelTrigger( true );
+		currentEvent->setPassesTkMuonChannelTrigger( true );
+		currentEvent->setPassesElectronChannelQCDTrigger( true );
+		currentEvent->setPassesMuonChannelQCDTrigger( passesMuonChannelMCTriggerReader->getVariable() );
+	}
+	else {
+		currentEvent->setPassesElectronChannelTrigger( true );
 		currentEvent->setPassesMuonChannelTrigger( true );
 		currentEvent->setPassesTkMuonChannelTrigger( true );		
-		// currentEvent->setPassesElectronChannelQCDTrigger( passesElectronChannelMCTriggerReader->getVariable() );
 		currentEvent->setPassesElectronChannelQCDTrigger( true );
-		// currentEvent->setPassesMuonChannelQCDTrigger( passesMuonChannelMCTriggerReader->getVariable() );
 		currentEvent->setPassesMuonChannelQCDTrigger( true );
 	}
 


### PR DESCRIPTION
-Add function to identify reHLT samples
-Apply trigger for reHLT samples in muon QCD region only

We currently only have muon trigger efficiencies.  We could apply the trigger in the MC for reHLT samples, but we don't have any scale factors at the moment.

We don't apply any SFs or efficiencies in the control regions, as they have been measured for real isolated muons/electrons, so we should use the MC info in the trigger for the control regions.