### PR TITLE
Phase space definition and b tagging efficiency corrections

### DIFF
--- a/interface/Analysers/PseudoTopAnalyser.h
+++ b/interface/Analysers/PseudoTopAnalyser.h
@@ -32,7 +32,7 @@ public:
 	static double const maxJetAbsEta_;
 
 protected:
-	bool passesEventSelection(const MCParticlePointer pseudoLepton, const JetCollection pseudoJets, const MCParticleCollection pseudoBs, const ParticleCollection allPseudoLeptons );
+	bool passesEventSelection(const MCParticlePointer pseudoLepton, const JetCollection pseudoJets, const MCParticleCollection pseudoBs, const MCParticleCollection allPseudoLeptons );
 };
 typedef boost::scoped_ptr<PseudoTopAnalyser> PseudoTopAnalyserLocalPtr;
 typedef boost::shared_ptr<PseudoTopAnalyser> PseudoTopAnalyserPtr;

--- a/interface/BTagWeight.h
+++ b/interface/BTagWeight.h
@@ -20,16 +20,16 @@ public:
 
 	bool filter(unsigned int t) const;
 
-	double getEfficiency( const unsigned int, const JetPointer ) const;
+	double getEfficiency( const unsigned int, const JetPointer, bool centralMCEfficiency=false ) const;
 	std::vector<double> getScaleFactor( const double, const JetPointer ) const;
 
 	std::vector<double> getBScaleFactor(const JetPointer, double uncertaintyFactor = 1.) const;
 	std::vector<double> getCScaleFactor(const JetPointer) const;
 	std::vector<double> getUDSGScaleFactor(const JetPointer) const;
 
-	float getBEfficiency(const JetPointer) const;
-	double getCEfficiency(const JetPointer) const;
-	double getUDSGEfficiency(const JetPointer) const;
+	float getBEfficiency(const JetPointer, bool centralMCEfficiency=false) const;
+	double getCEfficiency(const JetPointer, bool centralMCEfficiency=false) const;
+	double getUDSGEfficiency(const JetPointer, bool centralMCEfficiency=false) const;
 
 private:
 	unsigned int minNumberOfTags_;

--- a/interface/GlobalVariables.h
+++ b/interface/GlobalVariables.h
@@ -56,6 +56,10 @@ struct Globals {
 	static boost::shared_ptr<TH2F> cQuarkJet;
 	static boost::shared_ptr<TH2F> udsgQuarkJet;
 
+	static boost::shared_ptr<TH2F> bQuarkJet_PowhegPythia8;
+	static boost::shared_ptr<TH2F> cQuarkJet_PowhegPythia8;
+	static boost::shared_ptr<TH2F> udsgQuarkJet_PowhegPythia8;
+
 	//electrons
 	static ElectronAlgorithm::value electronAlgorithm;
 	static int ElectronScaleFactorSystematic;

--- a/interface/Readers/PseudoTopReader.h
+++ b/interface/Readers/PseudoTopReader.h
@@ -39,6 +39,7 @@ private:
     VariableReader<MultiDoublePointer> pseudoTop_lepton_pxReader_;
     VariableReader<MultiDoublePointer> pseudoTop_lepton_pyReader_;
     VariableReader<MultiDoublePointer> pseudoTop_lepton_pzReader_;
+    VariableReader<MultiIntPointer> pseudoTop_lepton_pdgIdReader_;
 
     // VariableReader< double > pseudoTop_met_energyReader_;
     // VariableReader< double > pseudoTop_met_pxReader_;
@@ -51,7 +52,7 @@ private:
     MCParticleCollection newPseudoTops_;
     MCParticlePointer newLeptonicW_;
     MCParticlePointer newLepton_;
-    ParticleCollection newAllLeptons_;
+    MCParticleCollection newAllLeptons_;
     JetCollection newJets_;
     MCParticleCollection newPseudoBs_;
     ParticlePointer newNeutrino_;

--- a/interface/RecoObjects/PseudoTopParticles.h
+++ b/interface/RecoObjects/PseudoTopParticles.h
@@ -38,8 +38,8 @@ public:
 	void setPseudoJets( JetCollection newPseudoJets );
 	JetCollection getPseudoJets() const;
 
-	void setAllPseudoLeptons( ParticleCollection newPseudoLeptons );
-	ParticleCollection getAllPseudoLeptons() const;
+	void setAllPseudoLeptons( MCParticleCollection newPseudoLeptons );
+	MCParticleCollection getAllPseudoLeptons() const;
 
 	void setPseudoNeutrino( ParticlePointer newPseudoNeutrino );
 	ParticlePointer getPseudoNeutrino() const;
@@ -54,7 +54,7 @@ protected:
 	MCParticleCollection pseudoTops_;
 	MCParticlePointer pseudoLeptonicW_;
 	MCParticlePointer pseudoLepton_;
-	ParticleCollection allPseudoLeptons_;
+	MCParticleCollection allPseudoLeptons_;
 	JetCollection pseudoJets_;
 	MCParticleCollection pseudoBs_;
 	ParticlePointer pseudoNeutrino_;

--- a/src/Analysers/PseudoTopAnalyser.cpp
+++ b/src/Analysers/PseudoTopAnalyser.cpp
@@ -39,7 +39,7 @@ void PseudoTopAnalyser::analyse(const EventPtr event) {
 	const MCParticleCollection pseudoTops = pseudoTopParticles->getPseudoTops();
 	const MCParticlePointer pseudoLeptonicW = pseudoTopParticles->getPseudoLeptonicW();
 	const MCParticlePointer pseudoLepton = pseudoTopParticles->getPseudoLepton();
-	const ParticleCollection allPseudoLeptons = pseudoTopParticles->getAllPseudoLeptons();
+	const MCParticleCollection allPseudoLeptons = pseudoTopParticles->getAllPseudoLeptons();
 	const MCParticleCollection pseudoBs = pseudoTopParticles->getPseudoBs();
 	const ParticlePointer pseudoMET = pseudoTopParticles->getPseudoMET();
 	const JetCollection pseudoJets = pseudoTopParticles->getPseudoJets();
@@ -122,9 +122,11 @@ void PseudoTopAnalyser::analyse(const EventPtr event) {
 		// Store info on lepton
 		treeMan_->Fill("pseudoLepton_pT", allPseudoLeptons[0]->pt() );
 		treeMan_->Fill("pseudoLepton_eta", allPseudoLeptons[0]->eta() );		
+
+		treeMan_->Fill("pseudoLepton_pdgId", fabs(allPseudoLeptons[0]->pdgId()));
 	}
 	else {
-		treeMan_->Fill("pseudoLepton_pT", 0 );
+		treeMan_->Fill("pseudoLepton_pT", -50 );
 		treeMan_->Fill("pseudoLepton_eta", -50 );
 	}
 
@@ -211,6 +213,7 @@ void PseudoTopAnalyser::createTrees() {
 	treeMan_->addBranch("isSemiLeptonicMuon", "F","Unfolding" + Globals::treePrefix_);
 
 	treeMan_->addBranch("passesGenEventSelection","F","Unfolding" + Globals::treePrefix_);
+	treeMan_->addBranch("pseudoLepton_pdgId", "F", "Unfolding" + Globals::treePrefix_);
 
 	// Branches for top
 	treeMan_->addBranch("pseudoTop_pT", "F", "Unfolding" + Globals::treePrefix_, false);
@@ -250,7 +253,7 @@ void PseudoTopAnalyser::createTrees() {
 
 }
 
-bool PseudoTopAnalyser::passesEventSelection( const MCParticlePointer pseudoLepton, const JetCollection pseudoJets, const MCParticleCollection pseudoBs, const ParticleCollection allPseudoLeptons ) {
+bool PseudoTopAnalyser::passesEventSelection( const MCParticlePointer pseudoLepton, const JetCollection pseudoJets, const MCParticleCollection pseudoBs, const MCParticleCollection allPseudoLeptons ) {
 
 	// Event selection taken from here : https://twiki.cern.ch/twiki/bin/view/LHCPhysics/ParticleLevelTopDefinitions
 	unsigned int numberGoodLeptons = 0;
@@ -259,7 +262,7 @@ bool PseudoTopAnalyser::passesEventSelection( const MCParticlePointer pseudoLept
 
 	// Lepton selection
 	for ( unsigned int leptonIndex = 0; leptonIndex < allPseudoLeptons.size(); ++ leptonIndex ) {
-		const ParticlePointer lepton = allPseudoLeptons.at(leptonIndex);
+		const MCParticlePointer lepton = allPseudoLeptons.at(leptonIndex);
 
 		// Check if this is a good signal type lepton
 		if ( lepton->pt() > minLeptonPt_ && fabs(lepton->eta()) < maxLeptonAbsEta_ ) {

--- a/src/BTagWeight.cpp
+++ b/src/BTagWeight.cpp
@@ -61,10 +61,6 @@ double BTagWeight::weight(const JetCollection jets, const int systematic, const 
 		// Get efficiency for this jet
 		const double eff = getEfficiency( hadronFlavour, jet );
 		const double eff_PowhegPythia8 = getEfficiency( hadronFlavour, jet, true );
-		// double scaleFactorCorrection = 1;
-		// if ( eff > 0 && hadronFlavour == 5 ) {
-		// 	scaleFactorCorrection = eff_PowhegPythia8 / eff;
-		// }
 
 		// Systematic Option
 		// 2 = b/c jet up
@@ -95,11 +91,6 @@ double BTagWeight::weight(const JetCollection jets, const int systematic, const 
 
 		(isLight==true) ? sfToUse = sfToUse_l : sfToUse = sfToUse_bc;
 
-		// if ( std::isnan(sfToUse) || sfToUse < 0.1 || sfToUse > 2 ) {
-		// 	std::cout << "Old/new scale factor, efficiency : " << sfToUse << " " << sfToUse * scaleFactorCorrection << " " << eff << std::endl;
-		// }
-		// sfToUse *= scaleFactorCorrection;
-
 		// if (isBTagged) {
 		// 	// std::cout << "BTagged eff*sf : " << eff*sfToUse << std::endl;
 		// 	bTaggedMCJet *= eff;
@@ -110,22 +101,18 @@ double BTagWeight::weight(const JetCollection jets, const int systematic, const 
 		// 	nonBTaggedDataJet *= ( 1 - eff*sfToUse );
 		// }
 
+		// NEW B tag scale factor
+		// We apply two weights, both calculated by the same method
+		// The first corrects the efficiencies in Powheg Pythia 8 MC (or the central MC, which should also be the same generator+PS used to derive the scale factors) to data
+		// The second corrects the efficiencies in the sample you are considering (e.g. Powheg+Herwig++) to Powheg Pythia 8 (or whichever central MC you are using)
+		// The denominator of the first weight cancels with the numerator of the second, so the total weight simplifies to this below
 		if (isBTagged) {
-			// std::cout << "BTagged eff*sf : " << eff*sfToUse << std::endl;
 			bTaggedMCJet *= eff_PowhegPythia8;
 			bTaggedDataJet *= eff*sfToUse;
 		}else{
-			// std::cout << "Not BTagged eff*sf : " << ( 1 - eff*sfToUse ) << std::endl;
 			nonBTaggedMCJet *= ( 1 - eff_PowhegPythia8 );
 			nonBTaggedDataJet *= ( 1 - eff*sfToUse );
 		}
-
-
-		// if ( std::isnan( nonBTaggedDataJet ) ) {
-		// 	std::cout << nonBTaggedDataJet << std::endl;
-		// 	std::cout << "Efficiencies : " << eff << " " << eff_PowhegPythia8 << " " << scaleFactorCorrection << std::endl;
-		// 	std::cout << "Old/new scale factor, efficiency : " << sfToUse << " " << sfToUse * scaleFactorCorrection << " " << eff << std::endl;
-		// }
 	}
 
 	double bTagWeight = (nonBTaggedDataJet * bTaggedDataJet) / (nonBTaggedMCJet * bTaggedMCJet);

--- a/src/BTagWeight.cpp
+++ b/src/BTagWeight.cpp
@@ -60,6 +60,11 @@ double BTagWeight::weight(const JetCollection jets, const int systematic, const 
 
 		// Get efficiency for this jet
 		const double eff = getEfficiency( hadronFlavour, jet );
+		const double eff_PowhegPythia8 = getEfficiency( hadronFlavour, jet, true );
+		// double scaleFactorCorrection = 1;
+		// if ( eff > 0 && hadronFlavour == 5 ) {
+		// 	scaleFactorCorrection = eff_PowhegPythia8 / eff;
+		// }
 
 		// Systematic Option
 		// 2 = b/c jet up
@@ -90,15 +95,37 @@ double BTagWeight::weight(const JetCollection jets, const int systematic, const 
 
 		(isLight==true) ? sfToUse = sfToUse_l : sfToUse = sfToUse_bc;
 
+		// if ( std::isnan(sfToUse) || sfToUse < 0.1 || sfToUse > 2 ) {
+		// 	std::cout << "Old/new scale factor, efficiency : " << sfToUse << " " << sfToUse * scaleFactorCorrection << " " << eff << std::endl;
+		// }
+		// sfToUse *= scaleFactorCorrection;
+
+		// if (isBTagged) {
+		// 	// std::cout << "BTagged eff*sf : " << eff*sfToUse << std::endl;
+		// 	bTaggedMCJet *= eff;
+		// 	bTaggedDataJet *= eff*sfToUse;
+		// }else{
+		// 	// std::cout << "Not BTagged eff*sf : " << ( 1 - eff*sfToUse ) << std::endl;
+		// 	nonBTaggedMCJet *= ( 1 - eff );
+		// 	nonBTaggedDataJet *= ( 1 - eff*sfToUse );
+		// }
+
 		if (isBTagged) {
 			// std::cout << "BTagged eff*sf : " << eff*sfToUse << std::endl;
-			bTaggedMCJet *= eff;
+			bTaggedMCJet *= eff_PowhegPythia8;
 			bTaggedDataJet *= eff*sfToUse;
 		}else{
 			// std::cout << "Not BTagged eff*sf : " << ( 1 - eff*sfToUse ) << std::endl;
-			nonBTaggedMCJet *= ( 1 - eff );
+			nonBTaggedMCJet *= ( 1 - eff_PowhegPythia8 );
 			nonBTaggedDataJet *= ( 1 - eff*sfToUse );
 		}
+
+
+		// if ( std::isnan( nonBTaggedDataJet ) ) {
+		// 	std::cout << nonBTaggedDataJet << std::endl;
+		// 	std::cout << "Efficiencies : " << eff << " " << eff_PowhegPythia8 << " " << scaleFactorCorrection << std::endl;
+		// 	std::cout << "Old/new scale factor, efficiency : " << sfToUse << " " << sfToUse * scaleFactorCorrection << " " << eff << std::endl;
+		// }
 	}
 
 	double bTagWeight = (nonBTaggedDataJet * bTaggedDataJet) / (nonBTaggedMCJet * bTaggedMCJet);
@@ -116,24 +143,25 @@ double BTagWeight::weight(const JetCollection jets, const int systematic, const 
 		cout << nonBTaggedDataJet << " " << bTaggedDataJet << " " << nonBTaggedMCJet << " " << bTaggedMCJet << endl;
 
 	}
+
 	return bTagWeight;
 }
 
 
-double BTagWeight::getEfficiency( const unsigned int hadronFlavour, const JetPointer jet ) const {
+double BTagWeight::getEfficiency( const unsigned int hadronFlavour, const JetPointer jet, bool centralMCEfficiency ) const {
 	if ( hadronFlavour == 5) { //b-quark
-		return getBEfficiency( jet );
+		return getBEfficiency( jet, centralMCEfficiency );
 	}
 	else if ( hadronFlavour == 4) { //c-quark
-		return getCEfficiency( jet );
+		return getCEfficiency( jet, centralMCEfficiency );
 	}
 	else if ( hadronFlavour == 0) { // u/d/s/g/unclassified-quark
-		return getUDSGEfficiency ( jet );
+		return getUDSGEfficiency ( jet, centralMCEfficiency );
 	}
 	else return 0.;
 }
 
-float BTagWeight::getBEfficiency(const JetPointer jet) const {
+float BTagWeight::getBEfficiency(const JetPointer jet, bool centralMCEfficiency ) const {
 	double jetPt = jet->pt();
 	const double jetEta = jet->eta();
 	const double maxPt = Globals::bQuarkJet->GetXaxis()->GetXmax();
@@ -144,7 +172,14 @@ float BTagWeight::getBEfficiency(const JetPointer jet) const {
 	}
 
 	int binNumber = Globals::bQuarkJet->FindBin( jetPt , jetEta );
-	float BTagEff = Globals::bQuarkJet->GetBinContent( binNumber );
+	float BTagEff = 1;
+
+	if ( centralMCEfficiency ) {
+		BTagEff = Globals::bQuarkJet_PowhegPythia8->GetBinContent( binNumber );
+	}
+	else {
+		BTagEff = Globals::bQuarkJet->GetBinContent( binNumber );
+	}
 
 	// if ( jetPt >= maxPt ) {
 	// 	std::cout << "Jet Pt : " << jetPt << ", Jet Eta : " << jetEta << std::endl;
@@ -153,7 +188,7 @@ float BTagWeight::getBEfficiency(const JetPointer jet) const {
 	return BTagEff;
 }
 
-double BTagWeight::getCEfficiency(const JetPointer jet) const {
+double BTagWeight::getCEfficiency(const JetPointer jet, bool centralMCEfficiency ) const {
 	double jetPt = jet->pt();
 	const double jetEta = jet->eta();
 	const double maxPt = Globals::cQuarkJet->GetXaxis()->GetXmax();
@@ -164,12 +199,19 @@ double BTagWeight::getCEfficiency(const JetPointer jet) const {
 	}
 
 	int binNumber = Globals::cQuarkJet->FindBin( jetPt , jetEta );
-	float BTagEff = Globals::cQuarkJet->GetBinContent( binNumber );	
+	float BTagEff = 1;
+
+	if ( centralMCEfficiency ) {
+		BTagEff = Globals::cQuarkJet_PowhegPythia8->GetBinContent( binNumber );
+	}
+	else {
+		BTagEff = Globals::cQuarkJet->GetBinContent( binNumber );
+	}
 	// std::cout << "C-quark Jet, B Tag Efficiency : " << BTagEff << std::endl;
 	return BTagEff;
 }
 
-double BTagWeight::getUDSGEfficiency(const JetPointer jet) const {
+double BTagWeight::getUDSGEfficiency(const JetPointer jet, bool centralMCEfficiency ) const {
 	double jetPt = jet->pt();
 	const double jetEta = jet->eta();
 	const double maxPt = Globals::udsgQuarkJet->GetXaxis()->GetXmax();
@@ -180,7 +222,14 @@ double BTagWeight::getUDSGEfficiency(const JetPointer jet) const {
 	}
 
 	int binNumber = Globals::udsgQuarkJet->FindBin( jetPt , jetEta );
-	float BTagEff = Globals::udsgQuarkJet->GetBinContent( binNumber );
+	float BTagEff = 1;
+
+	if ( centralMCEfficiency ) {
+		BTagEff = Globals::udsgQuarkJet_PowhegPythia8->GetBinContent( binNumber );
+	}
+	else {
+		BTagEff = Globals::udsgQuarkJet->GetBinContent( binNumber );
+	}
 	// std::cout << "UDS-quark Jet, B Tag Efficiency : " << BTagEff << std::endl;
 	return BTagEff;
 }

--- a/src/GlobalsVariables.cpp
+++ b/src/GlobalsVariables.cpp
@@ -46,6 +46,9 @@ boost::shared_ptr<TH2F> Globals::LeptonicRecoIncorrectPermHistogram = boost::sha
 boost::shared_ptr<TH2F> Globals::bQuarkJet = boost::shared_ptr<TH2F>(new TH2F());
 boost::shared_ptr<TH2F> Globals::cQuarkJet = boost::shared_ptr<TH2F>(new TH2F());
 boost::shared_ptr<TH2F> Globals::udsgQuarkJet = boost::shared_ptr<TH2F>(new TH2F());
+boost::shared_ptr<TH2F> Globals::bQuarkJet_PowhegPythia8 = boost::shared_ptr<TH2F>(new TH2F());
+boost::shared_ptr<TH2F> Globals::cQuarkJet_PowhegPythia8 = boost::shared_ptr<TH2F>(new TH2F());
+boost::shared_ptr<TH2F> Globals::udsgQuarkJet_PowhegPythia8 = boost::shared_ptr<TH2F>(new TH2F());
 
 //electrons
 ElectronAlgorithm::value Globals::electronAlgorithm = ElectronAlgorithm::ParticleFlow;

--- a/src/Python/ConfigFile.cpp
+++ b/src/Python/ConfigFile.cpp
@@ -843,6 +843,7 @@ void ConfigFile::getbQuarkJet(std::string btagEfficiencyFile) {
 	using namespace std;
 
 	std::string pathToBTagEff = getSampleBTagEffTag(sample_, mode_).append("bQuarkJets_Ratio_Hist");
+	std::string pathToBTagEff_PowhegPythia8 = "PowhegPythia8/bQuarkJets_Ratio_Hist";
 
 	if (!boost::filesystem::exists(btagEfficiencyFile)) {
 		cerr << "ConfigFile::getbQuarkJet(" << btagEfficiencyFile << "): could not find file" << endl;
@@ -854,6 +855,8 @@ void ConfigFile::getbQuarkJet(std::string btagEfficiencyFile) {
 	boost::scoped_ptr<TFile> file(TFile::Open(btagEfficiencyFile.c_str()));
 
 	Globals::bQuarkJet = (boost::shared_ptr<TH2F>) (TH2F*) file->Get(pathToBTagEff.c_str())->Clone();
+	Globals::bQuarkJet_PowhegPythia8 = (boost::shared_ptr<TH2F>) (TH2F*) file->Get(pathToBTagEff_PowhegPythia8.c_str())->Clone();
+
 	
 	file->Close();
 }
@@ -862,6 +865,7 @@ void ConfigFile::getcQuarkJet(std::string btagEfficiencyFile) {
 	using namespace std;
 
 	std::string pathToBTagEff = getSampleBTagEffTag(sample_, mode_).append("cQuarkJets_Ratio_Hist");
+	std::string pathToBTagEff_PowhegPythia8 = "PowhegPythia8/cQuarkJets_Ratio_Hist";
 
 	if (!boost::filesystem::exists(btagEfficiencyFile)) {
 		cerr << "ConfigFile::getcQuarkJet(" << btagEfficiencyFile << "): could not find file" << endl;
@@ -870,6 +874,8 @@ void ConfigFile::getcQuarkJet(std::string btagEfficiencyFile) {
 	pathToBTagEff = checkEffFileExists(btagEfficiencyFile, pathToBTagEff);
 	boost::scoped_ptr<TFile> file(TFile::Open(btagEfficiencyFile.c_str()));
 	Globals::cQuarkJet = (boost::shared_ptr<TH2F>) (TH2F*) file->Get(pathToBTagEff.c_str())->Clone();
+	Globals::cQuarkJet_PowhegPythia8 = (boost::shared_ptr<TH2F>) (TH2F*) file->Get(pathToBTagEff_PowhegPythia8.c_str())->Clone();
+
 	file->Close();
 }
 
@@ -878,6 +884,7 @@ void ConfigFile::getudsgQuarkJet(std::string btagEfficiencyFile) {
 	using namespace std;
 
 	std::string pathToBTagEff = getSampleBTagEffTag(sample_, mode_).append("udsgQuarkJets_Ratio_Hist");
+	std::string pathToBTagEff_PowhegPythia8 = "PowhegPythia8/udsgQuarkJets_Ratio_Hist";
 
 	if (!boost::filesystem::exists(btagEfficiencyFile)) {
 		cerr << "ConfigFile::getudsgQuarkJet(" << btagEfficiencyFile << "): could not find file" << endl;
@@ -886,6 +893,7 @@ void ConfigFile::getudsgQuarkJet(std::string btagEfficiencyFile) {
 	pathToBTagEff = checkEffFileExists(btagEfficiencyFile, pathToBTagEff);
 	boost::scoped_ptr<TFile> file(TFile::Open(btagEfficiencyFile.c_str()));
 	Globals::udsgQuarkJet = (boost::shared_ptr<TH2F>) (TH2F*) file->Get(pathToBTagEff.c_str())->Clone();
+	Globals::udsgQuarkJet_PowhegPythia8 = (boost::shared_ptr<TH2F>) (TH2F*) file->Get(pathToBTagEff_PowhegPythia8.c_str())->Clone();
 	file->Close();
 }
 
@@ -933,6 +941,7 @@ std::string ConfigFile::getSampleBTagEffTag(std::string sample, std::string mode
 	else if( sample == "TTJets_PowhegPythia8_hdampdown") return "PowhegPythia8_hdampup/";
 	else if( sample == "TTJets_PowhegPythia8_hdampup") return "PowhegPythia8_hdampdown/";
 	else if( sample == "TTJets_PowhegPythia8_erdOn") return "PowhegPythia8_erdOn/";
+	// else if( sample == "TTJets_PowhegPythia8_QCDbased_erdOn") return "PowhegPythia8_QCDbased_erdOn/";
 	else return "PowhegPythia8/";
 }
 

--- a/src/Readers/PseudoTopReader.cpp
+++ b/src/Readers/PseudoTopReader.cpp
@@ -31,6 +31,7 @@ PseudoTopReader::PseudoTopReader() :
     pseudoTop_lepton_pxReader_(),
     pseudoTop_lepton_pyReader_(),
     pseudoTop_lepton_pzReader_(),
+    pseudoTop_lepton_pdgIdReader_(),
     pseudoTop_met_exReader_(),
     pseudoTop_met_eyReader_(),
     pseudoTopParticles_( new PseudoTopParticles() ),
@@ -64,6 +65,7 @@ PseudoTopReader::PseudoTopReader(TChainPointer input) :
     pseudoTop_lepton_pxReader_(input, "PseudoTopLeptons.Px"),
     pseudoTop_lepton_pyReader_(input, "PseudoTopLeptons.Py"),
     pseudoTop_lepton_pzReader_(input, "PseudoTopLeptons.Pz"),
+    pseudoTop_lepton_pdgIdReader_(input, "PseudoTopLeptons.pdgId"),
     pseudoTop_met_exReader_(input, "PseudoTopMETs.Ex"),
     pseudoTop_met_eyReader_(input, "PseudoTopMETs.Ey"),
     pseudoTopParticles_( new PseudoTopParticles() ),
@@ -219,7 +221,11 @@ void PseudoTopReader::readPseudoTopParticles() {
         double px = pseudoTop_lepton_pxReader_.getVariableAt(index);
         double py = pseudoTop_lepton_pyReader_.getVariableAt(index);
         double pz = pseudoTop_lepton_pzReader_.getVariableAt(index);
-        newAllLeptons_.push_back( ParticlePointer( new Particle( energy, px, py, pz )) );
+        int pdgId = pseudoTop_lepton_pdgIdReader_.getIntVariableAt(index);
+
+        MCParticlePointer newLepton( new MCParticle( energy, px, py, pz ) );
+        newLepton->setPdgId( pdgId );
+        newAllLeptons_.push_back( newLepton );
     }
     pseudoTopParticles_->setAllPseudoLeptons( newAllLeptons_ );
 
@@ -249,6 +255,7 @@ void PseudoTopReader::initialise() {
     pseudoTop_lepton_pxReader_.initialiseBlindly();
     pseudoTop_lepton_pyReader_.initialiseBlindly();
     pseudoTop_lepton_pzReader_.initialiseBlindly();
+    pseudoTop_lepton_pdgIdReader_.initialiseBlindly();
 
     // pseudoTop_met_energyReader_.initialiseBlindly();
     // pseudoTop_met_pxReader_.initialiseBlindly();

--- a/src/RecoObjects/PseudoTopParticles.cpp
+++ b/src/RecoObjects/PseudoTopParticles.cpp
@@ -69,12 +69,12 @@ JetCollection PseudoTopParticles::getPseudoJets() const {
 	return pseudoJets_;
 }
 
-void PseudoTopParticles::setAllPseudoLeptons( ParticleCollection newPseudoLeptons ) {
+void PseudoTopParticles::setAllPseudoLeptons( MCParticleCollection newPseudoLeptons ) {
 	allPseudoLeptons_.clear();
 	allPseudoLeptons_ = newPseudoLeptons;
 }
 
-ParticleCollection PseudoTopParticles::getAllPseudoLeptons() const {
+MCParticleCollection PseudoTopParticles::getAllPseudoLeptons() const {
 	return allPseudoLeptons_;
 }
 


### PR DESCRIPTION
- Add pseudo lepton pdgId so we can separate electron and muon phase space

- Add extra b tagging efficiency corrections
These correct the efficiency in each MC sample (e.g. Powheg+Herwig++ or the fsr variations of the central Powheg Pythia8) to the efficiency in the central Powheg Pythia8 MC.  The additional weight needed for this cancels in part with the weight for correcting the central MC to data.